### PR TITLE
Justinchu/use graph

### DIFF
--- a/jax2onnx/plugins/_utils.py
+++ b/jax2onnx/plugins/_utils.py
@@ -98,11 +98,11 @@ def inline_reshape_initializer(
         return val  # not a constant → caller must insert a Reshape node
 
     np_arr = np.asarray(arr).reshape(new_shape)
-    reshaped = ir.Value(
-        name=ctx.fresh_name(name_hint),
-        type=val.type,  # keep dtype
-        shape=ir.Shape(tuple(int(s) for s in new_shape)),
-        const_value=ir.tensor(np_arr),
+    # Preserve dtype from the original value when available
+    target_dtype = getattr(getattr(val, "type", None), "dtype", None)
+    if target_dtype is not None and target_dtype in _IR_TO_NP_DTYPE:
+        np_arr = np_arr.astype(_IR_TO_NP_DTYPE[target_dtype], copy=False)
+
+    return ctx.builder.add_initializer_from_array(
+        name=ctx.fresh_name(name_hint), array=np_arr
     )
-    ctx._initializers.append(reshaped)
-    return reshaped

--- a/jax2onnx/plugins/jax/lax/_control_flow_utils.py
+++ b/jax2onnx/plugins/jax/lax/_control_flow_utils.py
@@ -117,6 +117,11 @@ def make_subgraph_context(parent_ctx: Any, *, prefix: str) -> Any:
     )
     child_ctx._function_mode = True
     child_ctx._inside_function_scope = True
+    # Ensure builder emits constants as nodes (Functions/subgraphs cannot have initializers)
+    try:
+        child_ctx.builder._function_mode = True
+    except Exception:
+        pass
     if hasattr(parent_ctx, "_keep_function_float32"):
         child_ctx._keep_function_float32 = getattr(
             parent_ctx, "_keep_function_float32", False

--- a/jax2onnx/plugins/jax/lax/squeeze.py
+++ b/jax2onnx/plugins/jax/lax/squeeze.py
@@ -28,17 +28,13 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def _const_i64(ctx: "IRContext", values, name_hint: str) -> ir.Value:
+    """Emit an INT64 constant via the builder to centralize initializer policy."""
     arr = np.asarray(values, dtype=np.int64)
     if arr.ndim == 0:
         arr = arr.reshape(1)
-    val = ir.Value(
-        name=ctx.fresh_name(name_hint),
-        type=ir.TensorType(ir.DataType.INT64),
-        shape=ir.Shape((arr.size,)),
-        const_value=ir.tensor(arr),
-    )
-    ctx._initializers.append(val)
-    return val
+    name = ctx.fresh_name(name_hint)
+    # Route through builder so function-mode and duplicate policies apply.
+    return ctx.builder.const_i64(name, arr.tolist())
 
 
 def _dim_const_value(dim) -> int | None:

--- a/tests/extra_tests/converter/test_ir_builder.py
+++ b/tests/extra_tests/converter/test_ir_builder.py
@@ -49,3 +49,89 @@ def test_ir_builder_initializer_view_assignment_roundtrip() -> None:
     builder.initializers.append(weight)
 
     assert builder.graph.initializers["weight"] is weight
+
+
+def _tensor_value(name: str, array: np.ndarray) -> ir.Value:
+    tensor = ir.tensor(array)
+    return ir.Value(
+        name=name,
+        shape=ir.Shape(array.shape if array.shape else ()),
+        type=ir.TensorType(ir.DataType.from_numpy(array.dtype)),
+        const_value=tensor,
+    )
+
+
+def test_ir_builder_initializer_append_duplicate_same_reuses_existing() -> None:
+    builder = IRBuilder(opset=18, enable_double_precision=False)
+
+    v1 = _tensor_value("w", np.array([1.0], dtype=np.float32))
+    v2 = _tensor_value("w", np.array([1.0], dtype=np.float32))
+
+    builder.initializers.append(v1)
+    before = builder.graph.initializers["w"]
+    builder.initializers.append(v2)
+
+    # The existing initializer remains canonical; duplicates do not overwrite
+    assert builder.graph.initializers["w"] is before
+    assert len(builder.graph.initializers) == 1
+
+
+def test_ir_builder_initializer_append_duplicate_different_raises() -> None:
+    builder = IRBuilder(opset=18, enable_double_precision=False)
+
+    v1 = _tensor_value("w", np.array([1.0], dtype=np.float32))
+    v2 = _tensor_value("w", np.array([2.0], dtype=np.float32))
+
+    builder.initializers.append(v1)
+
+    with pytest.raises(ValueError):
+        builder.initializers.append(v2)
+
+
+def test_ir_builder_add_initializer_from_scalar_duplicate_same_reuses() -> None:
+    builder = IRBuilder(opset=18, enable_double_precision=False)
+
+    v1 = builder.add_initializer_from_scalar(
+        name="alpha", value=np.array([3.14], dtype=np.float32)
+    )
+    v2 = builder.add_initializer_from_scalar(
+        name="alpha", value=np.array([3.14], dtype=np.float32)
+    )
+
+    assert v1 is v2
+    assert builder.graph.initializers["alpha"] is v1
+
+
+def test_ir_builder_add_initializer_from_scalar_duplicate_different_raises() -> None:
+    builder = IRBuilder(opset=18, enable_double_precision=False)
+
+    _ = builder.add_initializer_from_scalar(
+        name="beta", value=np.array([1.0], dtype=np.float32)
+    )
+    with pytest.raises(ValueError):
+        _ = builder.add_initializer_from_scalar(
+            name="beta", value=np.array([2.0], dtype=np.float32)
+        )
+
+
+def test_ir_builder_model_roundtrip_preserves_initializer_connections() -> None:
+    builder = IRBuilder(opset=18, enable_double_precision=False)
+
+    # Create an input and an initializer, then add a node that consumes both.
+    x = ir.Value(name="x", shape=ir.Shape((1,)), type=ir.TensorType(ir.DataType.FLOAT))
+    w = builder.add_initializer_from_scalar(
+        name="w", value=np.array([1.0], dtype=np.float32)
+    )
+    y = ir.Value(name="y", shape=ir.Shape((1,)), type=ir.TensorType(ir.DataType.FLOAT))
+
+    builder.inputs.append(x)
+    builder.add_node("Add", inputs=[x, w], outputs=[y])
+    builder.outputs.append(y)
+
+    model = builder.to_ir_model(name="m", ir_version=11)
+    g = model.graph
+    # There should be exactly one initializer named 'w', and the node should
+    # reference the same Value instance as stored in the graph's initializers.
+    w2 = g.initializers["w"]
+    node = list(g)[0]
+    assert node.inputs[1] is w2


### PR DESCRIPTION
Replaced direct initializer writes with graph.initializers.add and strict dedup (reuse identical, error on conflicts), routed subgraph constants via builder (Constant nodes), updated docs/tests.