### PR TITLE
natural function type name

### DIFF
--- a/docs/dev_guides/expect_graph_reference.md
+++ b/docs/dev_guides/expect_graph_reference.md
@@ -99,6 +99,16 @@ main data edge (by default we skip `Reshape`, `Identity`, `Cast`, `CastLike`,
 out into shape-building side chains, such as the CNN dynamic example where the
 `Transpose` output feeds both `Reshape` and the shape-construction subgraph.
 
+### Function naming compatibility
+
+Function exports now keep the original callable name as the node `op_type`
+(`TransformerBlock`, `MLPBlock`, …) and move the numeric suffix into
+`node.name`/`domain` (`TransformerBlock_2`, `custom.TransformerBlock_2`, …). To
+keep older expectations valid, `expect_graph` automatically strips trailing
+`_123` suffixes when comparing `op_type` and normalises graph filters such as
+`fn:custom.TransformerBlock_2`. Prefer matching on the base `op_type` unless a
+specific call-site needs to be distinguished by name.
+
 ## Practical tips
 
 - Prefer a single path that covers the interesting operators rather than every

--- a/docs/dev_guides/ir_reflection_guidelines.md
+++ b/docs/dev_guides/ir_reflection_guidelines.md
@@ -14,6 +14,7 @@ Document ONNX proto shims that still require reflection (`plugins/_post_check_on
 
 - **Typed APIs first** — Treat `ir.Attr`, `ir.Value`, and `ir.Graph` as immutable, typed objects. Avoid `getattr`, private field mutation, or redundant `None` guards; rely on the documented accessors instead.
 - **Use built-in graph iterators** — Iterate via `graph.nodes`, `graph.all_nodes()`, `value.consumers()`, `value.producer()`, and `ir.convenience.replace_all_uses_with` instead of constructing custom maps.
+- When working with `onnx_ir` graphs, prefer `graph.all_nodes()` so nested functions and control-flow subgraphs are traversed with the typed iterator. Only fall back to the ONNX proto mirrors (`function.node`) when you truly need the raw proto objects.
 - **Reuse shape & dtype helpers** — Use `onnx_ir.Shape.is_unknown_dim`, `ir.Shape(...)`, and `value.dtype` rather than cloning dtype/shape logic manually.
 - **Prefer existing passes** — Before adding bespoke optimizations, check the available ONNX Script passes (e.g., `fold_constants.FoldConstantsPass`, `LiftConstantsToInitializersPass`) and the IR optimizer docs.
 - **Keep helpers focused & typed** — Provide clear function signatures (e.g., `_attribute_iter(node: ir.Node) -> Iterable[ir.Attr]`) and avoid over-engineered utilities. Document non-obvious helpers.

--- a/jax2onnx/converter/function_scope.py
+++ b/jax2onnx/converter/function_scope.py
@@ -169,6 +169,17 @@ class FunctionScope:
         fn_domain = (self.domain or "").strip()
         if fn_domain:
             opset_imports.setdefault(fn_domain, body_opset)
+        try:
+            nodes_iter = list(body_graph.all_nodes())
+        except AttributeError:
+            try:
+                nodes_iter = list(body_graph.node)
+            except AttributeError:
+                nodes_iter = []
+        for node in nodes_iter:
+            dom = getattr(node, "domain", "") or ""
+            if dom:
+                opset_imports.setdefault(dom, body_opset)
         opset_imports.setdefault("", body_opset)
         body_graph.opset_imports.clear()
         body_graph.opset_imports.update(opset_imports)

--- a/tests/extra_tests/converter/test_onnx_function_call_params.py
+++ b/tests/extra_tests/converter/test_onnx_function_call_params.py
@@ -48,3 +48,47 @@ def test_onnx_function_consumes_call_time_param():
         no_unused_function_inputs=True,
     )
     assert check(model)
+
+
+@onnx_function
+class _SimpleBlock(nnx.Module):
+    def __init__(self, dim: int, *, rngs: nnx.Rngs):
+        self.linear = nnx.Linear(dim, dim, rngs=rngs)
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return self.linear(x)
+
+
+class _SimpleStack(nnx.Module):
+    def __init__(self, dim: int, *, rngs: nnx.Rngs):
+        self.block1 = _SimpleBlock(dim, rngs=rngs)
+        self.block2 = _SimpleBlock(dim, rngs=rngs)
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        return self.block2(self.block1(x))
+
+
+def test_function_node_names_are_human_friendly():
+    model = _SimpleStack(8, rngs=nnx.Rngs(0))
+    onnx_model = to_onnx(
+        model,
+        inputs=[jax.ShapeDtypeStruct((2, 8), jnp.float32)],
+        return_mode="proto",
+        model_name="simple_stack",
+    )
+
+    fn_nodes = [
+        node
+        for node in onnx_model.graph.node
+        if node.domain.startswith("custom") and node.op_type == "_SimpleBlock"
+    ]
+    assert [node.op_type for node in fn_nodes] == ["_SimpleBlock", "_SimpleBlock"]
+    assert [node.name for node in fn_nodes] == ["_SimpleBlock_1", "_SimpleBlock_2"]
+
+    functions = list(getattr(onnx_model, "functions", []))
+    assert len(functions) == 2
+    assert {fn.name for fn in functions} == {"_SimpleBlock"}
+    domains = {fn.domain for fn in functions}
+    assert len(domains) == 2
+    assert any(domain == "custom" for domain in domains)
+    assert any(domain.startswith("custom.") for domain in domains)


### PR DESCRIPTION
Kept ONNX function nodes using the base callable name, fixed call-site naming and opset imports, updated post-check/tests/docs accordingly.