### PR TITLE
Clean up graph passes and use common IR passes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,43 +1,43 @@
 repos:
-  # - repo: https://github.com/psf/black
-  #   rev: 25.1.0
-  #   hooks: 
-  #     - id: black
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks: 
+      - id: black
 
 
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: v0.11.5
-  #   hooks:
-  #     - id: ruff
-  #       args: [--fix, --unsafe-fixes] #, --unsafe-fixes]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.5
+    hooks:
+      - id: ruff
+        args: [--fix, --unsafe-fixes] #, --unsafe-fixes]
 
 
-  # - repo: local
-  #   hooks:
-  #     - id: forbid-reflection-patterns
-  #       name: Forbid isinstance/getattr reflection shims
-  #       entry: python3 scripts/check_forbidden_reflection.py
-  #       language: system
-  #       pass_filenames: false
-  #     - id: mypy
-  #       name: mypy (poetry)
-  #       entry: python3 scripts/run_mypy.py
-  #       language: system
-  #       pass_filenames: false
-  #     - id: ensure-path-markers
-  #       name: Ensure Python files start with their repository path marker
-  #       entry: python3 scripts/ensure_path_markers.py
-  #       language: system
-  #       types: [python]
-  #       pass_filenames: false
-  #     - id: check-ir-builder-usage
-  #       name: Enforce IR builder usage policies
-  #       entry: python3 scripts/check_ir_builder_usage.py --diff
-  #       language: system
-  #       types: [python]
-  #       pass_filenames: false
-  #     - id: enforce-variable-annotations
-  #       name: Ensure converter module variables are annotated
-  #       entry: python3 scripts/check_variable_annotations.py
-  #       language: system
-  #       pass_filenames: false
+  - repo: local
+    hooks:
+      - id: forbid-reflection-patterns
+        name: Forbid isinstance/getattr reflection shims
+        entry: python3 scripts/check_forbidden_reflection.py
+        language: system
+        pass_filenames: false
+      - id: mypy
+        name: mypy (poetry)
+        entry: python3 scripts/run_mypy.py
+        language: system
+        pass_filenames: false
+      - id: ensure-path-markers
+        name: Ensure Python files start with their repository path marker
+        entry: python3 scripts/ensure_path_markers.py
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: check-ir-builder-usage
+        name: Enforce IR builder usage policies
+        entry: python3 scripts/check_ir_builder_usage.py --diff
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: enforce-variable-annotations
+        name: Ensure converter module variables are annotated
+        entry: python3 scripts/check_variable_annotations.py
+        language: system
+        pass_filenames: false

--- a/jax2onnx/converter/ir_clone.py
+++ b/jax2onnx/converter/ir_clone.py
@@ -29,99 +29,127 @@ def clone_graph(graph: ir.Graph) -> ir.Graph:
 
     value_map: Dict[ir.Value, ir.Value] = {}
 
-    def clone_value(value: ir.Value) -> ir.Value:
-        if value in value_map:
-            return value_map[value]
-        metadata_props = dict(getattr(value, "metadata_props", {}))
-        kwargs = dict(
-            name=value.name,
-            shape=value.shape,
-            type=value.type,
-            doc_string=value.doc_string,
-            const_value=value.const_value,
-        )
-        cloned = ir.Value(**_assign_metadata(kwargs, metadata_props))
-        try:
-            cloned.meta.update(getattr(value, "meta", {}))
-        except Exception:
-            pass
-        value_map[value] = cloned
-        return cloned
+    def _collect_local_values(gr: ir.Graph) -> set[ir.Value]:
+        local: set[ir.Value] = set()
+        local.update(gr.inputs)
+        local.update(gr.outputs)
+        local.update(gr.initializers.values())
+        for node in gr:
+            local.update(node.outputs)
+        return local
 
-    def clone_optional_value(value: ir.Value | None) -> ir.Value | None:
-        if value is None:
-            return None
-        return clone_value(value)
+    def _clone_graph(gr: ir.Graph) -> ir.Graph:
+        local_values = _collect_local_values(gr)
 
-    def clone_attr(attr: Attr) -> Attr:
-        if attr.is_ref():
-            ref_name = attr.ref_attr_name
-            assert ref_name is not None, "Reference attribute must point to a name"
-            return RefAttr(attr.name, ref_name, attr.type, doc_string=attr.doc_string)
-        if attr.type == AttributeType.GRAPH:
-            cloned_graph = clone_graph(attr.as_graph())
-            return Attr(
-                attr.name,
-                AttributeType.GRAPH,
-                cloned_graph,
-                doc_string=attr.doc_string,
+        def clone_value(value: ir.Value) -> ir.Value:
+            if value in value_map:
+                return value_map[value]
+            if value not in local_values:
+                # Preserve outer-scope values; map to clones if they already exist.
+                mapped = value_map.get(value, value)
+                value_map[value] = mapped
+                return mapped
+            metadata_props = dict(getattr(value, "metadata_props", {}))
+            kwargs = dict(
+                name=value.name,
+                shape=value.shape,
+                type=value.type,
+                doc_string=value.doc_string,
+                const_value=value.const_value,
             )
-        if attr.type == AttributeType.GRAPHS:
-            cloned_graphs = [clone_graph(subgraph) for subgraph in attr.as_graphs()]
-            return Attr(
-                attr.name,
-                AttributeType.GRAPHS,
-                cloned_graphs,
-                doc_string=attr.doc_string,
+            cloned = ir.Value(**_assign_metadata(kwargs, metadata_props))
+            try:
+                cloned.meta.update(getattr(value, "meta", {}))
+            except Exception:
+                pass
+            value_map[value] = cloned
+            return cloned
+
+        def clone_optional_value(value: ir.Value | None) -> ir.Value | None:
+            if value is None:
+                return None
+            return clone_value(value)
+
+        def clone_attr(attr: Attr) -> Attr:
+            if attr.is_ref():
+                ref_name = attr.ref_attr_name
+                assert ref_name is not None, "Reference attribute must point to a name"
+                return RefAttr(
+                    attr.name, ref_name, attr.type, doc_string=attr.doc_string
+                )
+            if attr.type == AttributeType.GRAPH:
+                cloned_graph = _clone_graph(attr.as_graph())
+                return Attr(
+                    attr.name,
+                    AttributeType.GRAPH,
+                    cloned_graph,
+                    doc_string=attr.doc_string,
+                )
+            if attr.type == AttributeType.GRAPHS:
+                cloned_graphs = [
+                    _clone_graph(subgraph) for subgraph in attr.as_graphs()
+                ]
+                return Attr(
+                    attr.name,
+                    AttributeType.GRAPHS,
+                    cloned_graphs,
+                    doc_string=attr.doc_string,
+                )
+            # Attributes are immutable containers in onnx_ir so reusing the objects is fine,
+            # but we still clone simple containers to avoid sharing accidental references.
+            value = attr.value
+            if isinstance(value, dict):
+                value = dict(value)
+            elif isinstance(value, list):
+                value = list(value)
+            elif isinstance(value, tuple):
+                value = tuple(value)
+            return Attr(attr.name, attr.type, value, doc_string=attr.doc_string)
+
+        # Pre-seed clones for local values so subgraphs can remap outer references.
+        for val in local_values:
+            if val not in value_map:
+                clone_value(val)
+
+        def clone_node(node: ir.Node) -> ir.Node:
+            inputs = [clone_optional_value(val) for val in node.inputs]
+            outputs = [clone_value(val) for val in node.outputs]
+            attributes = [clone_attr(attr) for attr in node.attributes.values()]
+            metadata_props = dict(node.metadata_props)
+            node_kwargs = _assign_metadata({}, metadata_props)
+            cloned = ir.Node(
+                node.domain,
+                node.op_type,
+                inputs,
+                attributes,
+                overload=node.overload,
+                num_outputs=len(outputs),
+                outputs=outputs,
+                version=node.version,
+                name=node.name,
+                doc_string=node.doc_string,
+                **node_kwargs,
             )
-        # Attributes are immutable containers in onnx_ir so reusing the objects is fine,
-        # but we still clone simple containers to avoid sharing accidental references.
-        value = attr.value
-        if isinstance(value, dict):
-            value = dict(value)
-        elif isinstance(value, list):
-            value = list(value)
-        elif isinstance(value, tuple):
-            value = tuple(value)
-        return Attr(attr.name, attr.type, value, doc_string=attr.doc_string)
+            cloned.meta.update(node.meta)
+            return cloned
 
-    def clone_node(node: ir.Node) -> ir.Node:
-        inputs = [clone_optional_value(val) for val in node.inputs]
-        outputs = [clone_value(val) for val in node.outputs]
-        attributes = [clone_attr(attr) for attr in node.attributes.values()]
-        metadata_props = dict(node.metadata_props)
-        node_kwargs = _assign_metadata({}, metadata_props)
-        cloned = ir.Node(
-            node.domain,
-            node.op_type,
-            inputs,
-            attributes,
-            overload=node.overload,
-            num_outputs=len(outputs),
-            outputs=outputs,
-            version=node.version,
-            name=node.name,
-            doc_string=node.doc_string,
-            **node_kwargs,
+        input_values = [clone_value(value) for value in gr.inputs]
+        output_values = [clone_value(value) for value in gr.outputs]
+        cloned_nodes = [clone_node(node) for node in gr]
+        initializer_values = [clone_value(value) for value in gr.initializers.values()]
+        metadata_props = dict(gr.metadata_props)
+        graph_kwargs = _assign_metadata({}, metadata_props)
+        cloned_graph = ir.Graph(
+            input_values,
+            output_values,
+            nodes=cloned_nodes,
+            initializers=initializer_values,
+            doc_string=gr.doc_string,
+            opset_imports=dict(gr.opset_imports),
+            name=gr.name,
+            **graph_kwargs,
         )
-        cloned.meta.update(node.meta)
-        return cloned
+        cloned_graph.meta.update(gr.meta)
+        return cloned_graph
 
-    input_values = [clone_value(value) for value in graph.inputs]
-    output_values = [clone_value(value) for value in graph.outputs]
-    cloned_nodes = [clone_node(node) for node in graph]
-    initializer_values = [clone_value(value) for value in graph.initializers.values()]
-    metadata_props = dict(graph.metadata_props)
-    graph_kwargs = _assign_metadata({}, metadata_props)
-    cloned_graph = ir.Graph(
-        input_values,
-        output_values,
-        nodes=cloned_nodes,
-        initializers=initializer_values,
-        doc_string=graph.doc_string,
-        opset_imports=dict(graph.opset_imports),
-        name=graph.name,
-        **graph_kwargs,
-    )
-    cloned_graph.meta.update(graph.meta)
-    return cloned_graph
+    return _clone_graph(graph)

--- a/jax2onnx/converter/ir_postprocess.py
+++ b/jax2onnx/converter/ir_postprocess.py
@@ -126,6 +126,19 @@ def _loosen_graph_value_shapes(
             output.shape = unknown_shape
             _reset_tensor_type(output)
 
+    if force_rank_only:
+        for initializer in _iter_initializers(graph):
+            name = _value_name(initializer)
+            if name and name in io_names:
+                continue
+            unknown_shape = _unknown_shape_like(
+                initializer, force_rank_only=force_rank_only
+            )
+            if unknown_shape is None:
+                continue
+            initializer.shape = unknown_shape
+            _reset_tensor_type(initializer)
+
 
 def _tensor_to_numpy(tensor: object) -> np.ndarray | None:
     if tensor is None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4352,4 +4352,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "413de5a86f74edfb5ed950966a992fc7653ac3fa2bec9ba5c979c6d935f831da"
+content-hash = "315f5cb38e7fdf90e819fd1e7c9e75bb0f14c79788902187ccc27125eac2af1a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "onnxruntime>=1.19.2",
     "einops>=0.8.1",
     "equinox>=0.13.1",
-    "onnx-ir>=0.1.10",
+    "onnx-ir>=0.1.12",
     "huggingface-hub>=0.26.0",
 ]
 
@@ -47,7 +47,6 @@ tensorflow-cpu = "^2.18.0"
 tensorboardX = "*"
 pydantic = "*"
 
-
 [tool.poetry]
 name = "jax2onnx"
 version = "0.11.0"
@@ -62,6 +61,7 @@ packages = [
 name = "jax-releases"
 url = "https://storage.googleapis.com/jax-releases/jax_releases.html"
 priority = "supplemental"
+
 
 
 [tool.poetry.group.dev.dependencies]

--- a/scripts/ensure_path_markers.py
+++ b/scripts/ensure_path_markers.py
@@ -29,6 +29,7 @@ IGNORED_TOP_LEVEL = {
 IGNORED_PREFIXES = (
     ("tests", "examples"),
     ("tests", "primitives"),
+    ("tmp", "ir-py"),
 )
 
 


### PR DESCRIPTION
Use IR apis and common passes. Eliminate the use of getattr in the touched files.

Fixed a bug where CSE would cause the same value to duplicate as graph outputs, which is invalid in onnx.

**Removal of legacy helpers and predicates:**
- Removed unused or redundant helper predicates and functions such as `_is_elem`, `_count_consumers`, `_find_next_consumer_idx`, `_nodes`, and `_inputs` from both the test imports and test implementations, favoring direct use of IR containers and methods.

**Direct use of IR API:**
- Replaced custom value constructor `V_ir` with the standard `ir.val` throughout all tests, ensuring consistency with the IR API.
- Simplified graph and function construction by using `ir.Function` and passing functions directly to `ir.Model`, removing complex logic for function attachment.

**Test logic and assertion modernization:**
- Updated all node and input/output container accesses to use direct iteration (`list(g)` or `g.inputs`, `g.outputs`) instead of helper functions, and used direct attribute access for names.
- Updated assertions to reflect correct ONNX semantics, e.g., graph outputs must remain distinct objects, and adjusted tests accordingly.

**Documentation update:**
- Updated the IR optimizer authoring guide to recommend using built-in IR methods and containers directly, and to avoid unnecessary helpers.

@enpasos 
