### PR TITLE
fix: stabilize dynamic reshape folding and improve clip/maxtext examples

### DIFF
--- a/docs/user_guide/sota_examples/maxtext.md
+++ b/docs/user_guide/sota_examples/maxtext.md
@@ -31,6 +31,7 @@ poetry install --with maxtext
 ```
 
 > **Note:** This installs `omegaconf`, `transformers`, `sentencepiece`, `tensorflow-cpu`, and `tensorboardX`. `tensorflow-cpu` is required because MaxText uses `tensorboard` and some TF utilities.
+> It does **not** install the MaxText source tree itself; use `JAX2ONNX_MAXTEXT_SRC` (recommended) or install a `MaxText` package separately.
 
 ### Environment Configuration
 

--- a/jax2onnx/plugins/examples/maxtext/maxtext_models.py
+++ b/jax2onnx/plugins/examples/maxtext/maxtext_models.py
@@ -78,7 +78,13 @@ else:
         elif spec.origin:
             MAXTEXT_PKG_PATH: Path | None = Path(spec.origin).resolve().parent
     else:
-        logger.warning("MaxText module not found in python path.")
+        logger.info(
+            "MaxText module not found in python path; skipping optional "
+            "examples.maxtext registration. "
+            "'poetry install --with maxtext' installs helper deps only; "
+            "also provide MaxText via JAX2ONNX_MAXTEXT_SRC "
+            "(recommended) or an installed 'MaxText' package."
+        )
 
 if MAXTEXT_PKG_PATH is not None:
     MAXTEXT_CONFIG_DIR: Path | None = MAXTEXT_PKG_PATH / "configs"

--- a/jax2onnx/plugins/examples/nnx/simple_clip.py
+++ b/jax2onnx/plugins/examples/nnx/simple_clip.py
@@ -1,0 +1,74 @@
+# jax2onnx/plugins/examples/nnx/simple_clip.py
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from flax import nnx
+
+from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.plugin_system import (
+    construct_and_call,
+    register_example,
+    with_rng_seed,
+)
+
+
+class SimpleModel(nnx.Module):
+    def __init__(self, *, rngs: nnx.Rngs):
+        pass
+
+    def __call__(self, input):
+        x = jnp.clip(input, 0.0, 1.0)
+        return x
+
+
+register_example(
+    component="SimpleModel",
+    description="Minimal NNX model that applies jnp.clip.",
+    source="https://github.com/enpasos/jax2onnx/issues/178",
+    since="0.11.3",
+    context="examples.nnx",
+    children=["jax.numpy.clip"],
+    testcases=[
+        {
+            "testcase": "simple_model_clip_nhwc",
+            "callable": construct_and_call(
+                SimpleModel,
+                rngs=with_rng_seed(0),
+            ),
+            "input_shapes": [(1, 8, 8, 3)],
+            "expected_output_shapes": [(1, 8, 8, 3)],
+            "run_only_f32_variant": True,
+            "post_check_onnx_graph": EG(
+                [
+                    (
+                        "Clip:1x8x8x3",
+                        {"counts": {"Clip": 1, "Transpose": 0}},
+                    )
+                ],
+                no_unused_inputs=True,
+            ),
+        },
+        {
+            "testcase": "simple_model_clip_nchw_io",
+            "callable": construct_and_call(
+                SimpleModel,
+                rngs=with_rng_seed(0),
+            ),
+            "input_shapes": [(1, 8, 8, 3)],
+            "expected_output_shapes": [(1, 3, 8, 8)],
+            "inputs_as_nchw": [0],
+            "outputs_as_nchw": [0],
+            "run_only_f32_variant": True,
+            "post_check_onnx_graph": EG(
+                [
+                    (
+                        "Clip:1x3x8x8",
+                        {"counts": {"Clip": 1, "Transpose": 0}},
+                    )
+                ],
+                no_unused_inputs=True,
+            ),
+        },
+    ],
+)


### PR DESCRIPTION
- lower jnp.clip to ONNX Clip for scalar bounds (fallback to Max/Min for broadcast bounds)
- include Max/Min/Clip in elementwise optimization sets
- guard reshape-pair folding to skip non-isolated chains with extra consumers
- add regression coverage for reshape folding edge case in ir_optimizations tests
- add examples.nnx SimpleModel clip example testcase
- clarify MaxText optional setup in logs/docs (maxtext deps vs MaxText source/package)