### PR TITLE
fix(gather): fix dynamic-slice gather lowering behind welch export (i…

### DIFF
--- a/jax2onnx/plugins/jax/lax/gather_helpers.py
+++ b/jax2onnx/plugins/jax/lax/gather_helpers.py
@@ -65,6 +65,7 @@ def index_lastdim_gather_to_gir(
             "op": "index_lastdim_gather",
             "gather_indices": gather_indices,
             "input_shape": input_shape,
+            "output_shape": list(input_shape[:-1]) + [len(gather_indices)],
         }
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # file: pyproject.toml
 [project]
 name = "jax2onnx"
-version = "0.11.2"
+version = "0.11.3"
 description = "export JAX to ONNX"
 authors = [{ name = "enpasos", email = "matthias.unverzagt@enpasos.ai" }]
 readme = "README.md"

--- a/tests/extra_tests/test_gather_modes.py
+++ b/tests/extra_tests/test_gather_modes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 import numpy as np
 import pytest
 
@@ -67,5 +68,34 @@ def test_gather_dynamic_window_matches_onnx_ir():
         session.get_inputs()[1].name: np.asarray(start, dtype=np.int32),
     }
     (got,) = session.run(None, feeds)
+
+    np.testing.assert_allclose(expected, got, rtol=1e-6, atol=1e-6)
+
+
+def _vmap_dynamic_slice_windows(x: jnp.ndarray) -> jnp.ndarray:
+    nperseg = 8
+    step = 4
+    starts = jnp.arange(x.shape[-1] - nperseg + 1, step=step, dtype=jnp.int32)
+    slice_func = partial(
+        lax.dynamic_slice_in_dim, operand=x, slice_size=nperseg, axis=-1
+    )
+    return jax.vmap(slice_func, out_axes=-2)(start_index=starts)
+
+
+def test_issue_182_vmap_dynamic_slice_windows_matches_onnx_ir():
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(1, 64)).astype(np.float32)
+    expected = np.asarray(_vmap_dynamic_slice_windows(data))
+
+    onnx_model = to_onnx(
+        _vmap_dynamic_slice_windows,
+        [jax.ShapeDtypeStruct(data.shape, jnp.float32)],
+        model_name="issue182_vmap_dynamic_slice_windows",
+        enable_double_precision=False,
+    )
+
+    ort = pytest.importorskip("onnxruntime")
+    session = ort.InferenceSession(onnx_model.SerializeToString())
+    (got,) = session.run(None, {session.get_inputs()[0].name: data})
 
     np.testing.assert_allclose(expected, got, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
…ssue #182)

- preserve start-index metadata for passthrough dims in gather GIR
- carry index-batch shape/target-dimension metadata into dynamic-range->gather rewrite
- make target-dimension ordering deterministic during GIR construction
- add output_shape metadata for index_lastdim_gather
- add regression test for vmap(dynamic_slice_in_dim) gather windows
- verify jax.scipy.signal.welch export no longer raises invert_transpose AssertionError