### PR TITLE
fix: support NNX conv special padding and reduce warning noise

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -15,6 +15,7 @@
 * **Leverage native ONNX Attention for Equinox MHA:** Export `eqx.nn.MultiheadAttention` via ONNX `Attention` when targeting opset >= 23, while keeping the existing fallback path for older opsets.
 * **Add Flax NNX grouped-query attention support:** Export `nnx.dot_product_attention` and `nnx.MultiHeadAttention` when `num_heads != num_kv_heads`, using native ONNX `Attention` on opset >= 23 and a compatible grouped-K/V expansion fallback on older opsets.
 * **Add Exclusive Self Attention example coverage:** Export XSA-style attention blocks on top of the existing attention lowering, preserving native ONNX `Attention` on opset >= 23 and the standard fallback path on older opsets.
+* **Fix Flax NNX conv special padding export:** Align `nnx.Conv` with upstream Flax handling for `REFLECT`, `CIRCULAR`, and `CAUSAL` padding so these modes export correctly through `to_onnx`.
 
 ## Current Version
 

--- a/jax2onnx/converter/conversion_api.py
+++ b/jax2onnx/converter/conversion_api.py
@@ -834,6 +834,8 @@ def to_onnx(
                     for val in values:
                         if val is None:
                             continue
+                        if not hasattr(val, "shape"):
+                            continue
                         vid = id(val)
                         if vid in seen:
                             continue

--- a/jax2onnx/converter/conversion_api.py
+++ b/jax2onnx/converter/conversion_api.py
@@ -834,7 +834,7 @@ def to_onnx(
                     for val in values:
                         if val is None:
                             continue
-                        if not hasattr(val, "shape"):
+                        if not isinstance(val, ir.Value):
                             continue
                         vid = id(val)
                         if vid in seen:

--- a/jax2onnx/plugins/_ir_shapes.py
+++ b/jax2onnx/plugins/_ir_shapes.py
@@ -43,13 +43,23 @@ def _as_ir_dim_label(dim: object) -> Union[str, int, None]:
     if isinstance(dim, ir.SymbolicDim):
         value = dim.value
         if isinstance(value, str):
-            return value
+            return value if value not in {"", "?", "None"} else None
+        if value is None:
+            return None
         text = str(dim)
-        return text if text else None
+        return text if text and text not in {"?", "None"} else None
     if isinstance(dim, str):
-        return dim
+        return dim if dim not in {"", "?", "None"} else None
+    for attr in ("value", "param", "name", "symbol"):
+        attr_val = getattr(dim, attr, None)
+        if isinstance(attr_val, (int, np.integer)):
+            return int(attr_val)
+        if isinstance(attr_val, str):
+            return attr_val if attr_val not in {"", "?", "None"} else None
+        if attr_val is None:
+            continue
     text = str(dim)
-    return text if text else None
+    return text if text and text not in {"?", "None"} else None
 
 
 def _to_ir_dim_for_shape(dim: object) -> DimValue:
@@ -60,9 +70,13 @@ def _to_ir_dim_for_shape(dim: object) -> DimValue:
     if isinstance(dim, (int, np.integer)):
         return int(dim)
     if isinstance(dim, str):
-        return ir.SymbolicDim(dim)
-    text = str(dim)
-    return ir.SymbolicDim(text) if text else None
+        return ir.SymbolicDim(dim) if dim not in {"", "?", "None"} else None
+    label = _as_ir_dim_label(dim)
+    if label is None:
+        return None
+    if isinstance(label, int):
+        return label
+    return ir.SymbolicDim(label)
 
 
 def _is_static_int(d: object) -> bool:

--- a/jax2onnx/plugins/equinox/eqx/nn/batch_norm.py
+++ b/jax2onnx/plugins/equinox/eqx/nn/batch_norm.py
@@ -14,6 +14,7 @@ _EQX_BATCH_NORM: Final[eqx.nn.BatchNorm] = eqx.nn.BatchNorm(
     input_size=3,
     axis_name="batch",
     inference=True,
+    mode="ema",
 )
 _EQX_BATCH_NORM_STATE: Final[eqx.nn.State] = eqx.nn.State(_EQX_BATCH_NORM)
 

--- a/jax2onnx/plugins/flax/nnx/conv.py
+++ b/jax2onnx/plugins/flax/nnx/conv.py
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 from jax import lax
 from jax.extend.core import Primitive
 from flax import nnx
+from flax.nnx.nn import linear as nnx_linear
 import onnx_ir as ir
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -92,6 +93,31 @@ EXPECT_FLATTEN_TCT: Final = EG(
         )
     ]
 )
+
+EXPECT_SPECIAL_PADDING_TCT: Final = EG(
+    [
+        (
+            "Transpose -> Conv -> Transpose",
+            {
+                "counts": {
+                    "Transpose": 2,
+                    "Conv": 1,
+                }
+            },
+        )
+    ],
+    no_unused_inputs=True,
+)
+
+_REFLECT_INPUT_2D: Final[np.ndarray] = np.linspace(
+    -1.0, 1.0, num=1 * 128 * 128 * 1, dtype=np.float32
+).reshape(1, 128, 128, 1)
+_CIRCULAR_INPUT_2D: Final[np.ndarray] = np.linspace(
+    -0.75, 0.75, num=1 * 18 * 20 * 4, dtype=np.float32
+).reshape(1, 18, 20, 4)
+_CAUSAL_INPUT_1D: Final[np.ndarray] = np.linspace(
+    -0.5, 0.5, num=1 * 32 * 8, dtype=np.float32
+).reshape(1, 32, 8)
 
 
 # ---------- helper: normalize value metadata so exported graphs show shapes ----------
@@ -177,6 +203,16 @@ def _calc_out_spatial(
 def _all_ones(seq: Sequence[int]) -> bool:
     """True if all elements are 1."""
     return all(int(v) == 1 for v in seq)
+
+
+def _maybe_broadcast_conv_param(
+    value: int | Sequence[int] | None, rank: int
+) -> tuple[int, ...]:
+    if value is None:
+        value = 1
+    if isinstance(value, int):
+        return (int(value),) * rank
+    return tuple(int(v) for v in value)
 
 
 def _same_upper_pads_static(
@@ -615,6 +651,40 @@ def _conv(
             "post_check_onnx_graph": EXPECT_TCT,
         },
         {
+            "testcase": "conv_2d_reflect_padding",
+            "callable": construct_and_call(
+                nnx.Conv,
+                1,
+                1,
+                kernel_size=(3, 3),
+                padding="REFLECT",
+                dtype=with_requested_dtype(),
+                param_dtype=with_requested_dtype(),
+                rngs=with_rng_seed(0),
+            ),
+            "input_values": [_REFLECT_INPUT_2D],
+            "run_only_f32_variant": True,
+            "expected_output_shapes": [(1, 128, 128, 1)],
+            "post_check_onnx_graph": EXPECT_SPECIAL_PADDING_TCT,
+        },
+        {
+            "testcase": "conv_2d_circular_padding",
+            "callable": construct_and_call(
+                nnx.Conv,
+                4,
+                6,
+                kernel_size=(5, 3),
+                padding="CIRCULAR",
+                dtype=with_requested_dtype(),
+                param_dtype=with_requested_dtype(),
+                rngs=with_rng_seed(0),
+            ),
+            "input_values": [_CIRCULAR_INPUT_2D],
+            "run_only_f32_variant": True,
+            "expected_output_shapes": [(1, 18, 20, 6)],
+            "post_check_onnx_graph": EXPECT_SPECIAL_PADDING_TCT,
+        },
+        {
             "testcase": "conv_different_kernel",
             "callable": construct_and_call(
                 nnx.Conv,
@@ -689,6 +759,23 @@ def _conv(
             "run_only_f32_variant": True,
             "expected_output_shapes": [(32, 16, 16, 8)],
             "post_check_onnx_graph": EXPECT_TCT,
+        },
+        {
+            "testcase": "conv_1d_causal_padding",
+            "callable": construct_and_call(
+                nnx.Conv,
+                8,
+                12,
+                kernel_size=(5,),
+                padding="CAUSAL",
+                dtype=with_requested_dtype(),
+                param_dtype=with_requested_dtype(),
+                rngs=with_rng_seed(0),
+            ),
+            "input_values": [_CAUSAL_INPUT_1D],
+            "run_only_f32_variant": True,
+            "expected_output_shapes": [(1, 32, 12)],
+            "post_check_onnx_graph": EXPECT_SPECIAL_PADDING_TCT,
         },
         {
             "testcase": "conv_1d",
@@ -1301,9 +1388,9 @@ class ConvPlugin(PrimitiveLeafPlugin):
     """
     IR-only plugin for flax.nnx.Conv → ONNX Conv.
     Assumes NHWC input/output in user space; converts to NCHx… internally.
-    Supports 1D/2D/3D, SAME/VALID or explicit pads, strides/dilations, and groups.
-    Also supports "mixed-dimension" inputs (e.g., 1D conv on higher-rank NHWC)
-    by flattening non-participating spatial dims into batch and reshaping back.
+    Supports 1D/2D/3D, explicit pads, special padding shims used by flax.nnx.Conv,
+    strides/dilations, and groups. Mixed-dimension inputs are flattened to a single
+    leading batch like upstream flax.nnx.Conv and restored after the primitive call.
     """
 
     _PRIM: ClassVar[Primitive] = Primitive("nnx.conv")
@@ -1324,29 +1411,89 @@ class ConvPlugin(PrimitiveLeafPlugin):
         ConvPlugin._ORIGINAL_CALL = real_orig
         prim = ConvPlugin._PRIM
 
-        def patched(self, x):
-            # Pull config from the nnx.Conv instance
-            strides = getattr(self, "strides", 1)
-            padding = getattr(self, "padding", "VALID")
-            dilations = getattr(self, "kernel_dilation", 1)
-            groups = getattr(self, "feature_group_count", 1)
-            use_bias = bool(getattr(self, "use_bias", True))
-            kernel = self.kernel.value
-            # Keep arity stable, but avoid creating broadcast nodes when bias is disabled.
-            if use_bias:
-                if (
-                    getattr(self, "bias", None) is not None
-                    and getattr(self.bias, "value", None) is not None
-                ):
-                    bias = self.bias.value
-                else:
-                    # vector bias expected by use_bias=True path
-                    bias = jnp.zeros((kernel.shape[-1],), dtype=kernel.dtype)
+        def patched(self, x, out_sharding=None):
+            original_x = x
+            kernel_size = getattr(self, "kernel_size", ())
+            if isinstance(kernel_size, int):
+                kernel_size = (kernel_size,)
             else:
-                # scalar literal (no broadcast_in_dim in the JAXPR)
-                bias = jnp.asarray(0, dtype=kernel.dtype)
+                kernel_size = tuple(kernel_size)
+            if not kernel_size:
+                return real_orig(self, original_x, out_sharding=out_sharding)
 
-            return prim.bind(
+            num_batch_dimensions = x.ndim - (len(kernel_size) + 1)
+            if num_batch_dimensions < 0:
+                return real_orig(self, original_x, out_sharding=out_sharding)
+
+            input_batch_shape = None
+            if num_batch_dimensions != 1:
+                input_batch_shape = x.shape[:num_batch_dimensions]
+                x = jnp.reshape(x, (-1,) + x.shape[num_batch_dimensions:])
+
+            strides = _maybe_broadcast_conv_param(
+                getattr(self, "strides", 1), len(kernel_size)
+            )
+            input_dilation = _maybe_broadcast_conv_param(
+                getattr(self, "input_dilation", 1), len(kernel_size)
+            )
+            if any(d != 1 for d in input_dilation):
+                return real_orig(self, original_x, out_sharding=out_sharding)
+
+            dilations = _maybe_broadcast_conv_param(
+                getattr(self, "kernel_dilation", 1), len(kernel_size)
+            )
+            padding = nnx_linear.canonicalize_padding(
+                getattr(self, "padding", "VALID"),
+                len(kernel_size),
+            )
+            if padding in ("CIRCULAR", "REFLECT"):
+                kernel_size_dilated = [
+                    (k - 1) * d + 1 for k, d in zip(kernel_size, dilations)
+                ]
+                pads = (
+                    [(0, 0)]
+                    + [((k - 1) // 2, k // 2) for k in kernel_size_dilated]
+                    + [(0, 0)]
+                )
+                padding_mode = {
+                    "CIRCULAR": "wrap",
+                    "REFLECT": "reflect",
+                }[padding]
+                x = jnp.pad(x, pads, mode=padding_mode)
+                padding = "VALID"
+            elif padding == "CAUSAL":
+                if len(kernel_size) != 1:
+                    raise ValueError(
+                        "Causal padding is only implemented for 1D convolutions."
+                    )
+                left_pad = dilations[0] * (kernel_size[0] - 1)
+                x = jnp.pad(x, [(0, 0), (left_pad, 0), (0, 0)])
+                padding = "VALID"
+
+            groups = int(getattr(self, "feature_group_count", 1))
+            use_bias = bool(getattr(self, "use_bias", True))
+            kernel = self.kernel[...]
+            if getattr(self, "mask", None) is not None:
+                if self.mask.shape != kernel.shape:
+                    raise ValueError(
+                        "Mask needs to have the same shape as weights. "
+                        f"Shapes are: {self.mask.shape}, {kernel.shape}"
+                    )
+                kernel = kernel * self.mask
+            bias = self.bias[...] if getattr(self, "bias", None) is not None else None
+
+            x, kernel, bias = self.promote_dtype(
+                (x, kernel, bias),
+                dtype=getattr(self, "dtype", None),
+            )
+
+            if use_bias:
+                if bias is None:
+                    bias = jnp.zeros((int(kernel.shape[-1]),), dtype=x.dtype)
+            else:
+                bias = jnp.asarray(0, dtype=x.dtype)
+
+            y = prim.bind(
                 x,
                 kernel,
                 bias,
@@ -1354,9 +1501,12 @@ class ConvPlugin(PrimitiveLeafPlugin):
                 strides=strides,
                 padding=padding,
                 dilations=dilations,
-                dimension_numbers=getattr(self, "dimension_numbers", None),
-                feature_group_count=int(groups),
+                dimension_numbers=nnx_linear._conv_dimension_numbers(x.shape),
+                feature_group_count=groups,
             )
+            if input_batch_shape is not None:
+                y = jnp.reshape(y, input_batch_shape + y.shape[1:])
+            return y
 
         # Mark the shim so a subsequent patch can recover the original.
         # mypy: 'patched' is typed as a plain Callable, so attribute writes need an Any cast

--- a/jax2onnx/plugins/flax/nnx/conv.py
+++ b/jax2onnx/plugins/flax/nnx/conv.py
@@ -1428,7 +1428,11 @@ class ConvPlugin(PrimitiveLeafPlugin):
             input_batch_shape = None
             if num_batch_dimensions != 1:
                 input_batch_shape = x.shape[:num_batch_dimensions]
-                x = jnp.reshape(x, (-1,) + x.shape[num_batch_dimensions:])
+                flat_batch = reduce(mul, input_batch_shape, 1)
+                x = lax.reshape(
+                    x,
+                    (flat_batch,) + x.shape[num_batch_dimensions:],
+                )
 
             strides = _maybe_broadcast_conv_param(
                 getattr(self, "strides", 1), len(kernel_size)
@@ -1505,7 +1509,7 @@ class ConvPlugin(PrimitiveLeafPlugin):
                 feature_group_count=groups,
             )
             if input_batch_shape is not None:
-                y = jnp.reshape(y, input_batch_shape + y.shape[1:])
+                y = lax.reshape(y, input_batch_shape + y.shape[1:])
             return y
 
         # Mark the shim so a subsequent patch can recover the original.

--- a/jax2onnx/plugins/jax/lax/scan.py
+++ b/jax2onnx/plugins/jax/lax/scan.py
@@ -476,9 +476,12 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
         {
             "testcase": "scan_captured_scalar_f64",
             "callable": (
-                lambda dt=jnp.asarray(0.1, dtype=jnp.float64): (
+                lambda dt=np.float64(0.1): (
                     jax.lax.scan(
-                        lambda carry, _: (carry + dt, carry + dt),
+                        lambda carry, _: (
+                            carry + jnp.asarray(dt, dtype=jnp.float64),
+                            carry + jnp.asarray(dt, dtype=jnp.float64),
+                        ),
                         jnp.asarray(0.0, dtype=jnp.float64),
                         xs=None,
                         length=3,
@@ -513,10 +516,13 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
         {
             "testcase": "scan_rank0_sequence_vectorized_f64",
             "callable": (
-                lambda xs_vec=jnp.arange(4, dtype=jnp.float64): jax.lax.scan(
+                lambda xs_vec=np.arange(4, dtype=np.float64): jax.lax.scan(
                     lambda carry, xs: (carry + xs[0] + xs[1], carry),
                     0.0,
-                    xs=(xs_vec, jnp.full(xs_vec.shape, 0.1, dtype=jnp.float64)),
+                    xs=(
+                        jnp.asarray(xs_vec, dtype=jnp.float64),
+                        jnp.full(np.shape(xs_vec), 0.1, dtype=jnp.float64),
+                    ),
                 )[1]
             ),
             "input_shapes": [],
@@ -670,9 +676,12 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
         {
             "testcase": "scan_captured_vector_with_xs_f64",
             "callable": (
-                lambda xs, dt=jnp.asarray([0.1, -0.2], dtype=jnp.float64): (
+                lambda xs, dt=np.asarray([0.1, -0.2], dtype=np.float64): (
                     jax.lax.scan(
-                        lambda carry, x: (carry + dt * x, carry + dt * x),
+                        lambda carry, x: (
+                            carry + jnp.asarray(dt, dtype=jnp.float64) * x,
+                            carry + jnp.asarray(dt, dtype=jnp.float64) * x,
+                        ),
                         jnp.zeros((2,), dtype=jnp.float64),
                         xs,
                     )[1]

--- a/jax2onnx/plugins/jax/lax/scan.py
+++ b/jax2onnx/plugins/jax/lax/scan.py
@@ -306,6 +306,34 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
     return y1, y2
 
 
+def _scan_captured_scalar_f64() -> Any:
+    dt = jnp.asarray(0.1, dtype=jnp.float64)
+    return jax.lax.scan(
+        lambda carry, _: (carry + dt, carry + dt),
+        jnp.asarray(0.0, dtype=jnp.float64),
+        xs=None,
+        length=3,
+    )[1]
+
+
+def _scan_rank0_sequence_vectorized_f64() -> Any:
+    xs_vec = jnp.arange(4, dtype=jnp.float64)
+    return jax.lax.scan(
+        lambda carry, xs: (carry + xs[0] + xs[1], carry),
+        0.0,
+        xs=(xs_vec, jnp.full(xs_vec.shape, 0.1, dtype=jnp.float64)),
+    )[1]
+
+
+def _scan_captured_vector_with_xs_f64(xs: Any) -> Any:
+    dt = jnp.asarray([0.1, -0.2], dtype=jnp.float64)
+    return jax.lax.scan(
+        lambda carry, x: (carry + dt * x, carry + dt * x),
+        jnp.zeros((2,), dtype=jnp.float64),
+        xs,
+    )[1]
+
+
 @register_primitive(
     jaxpr_primitive=jax.lax.scan_p.name,
     jax_doc="https://docs.jax.dev/en/latest/_autosummary/jax.lax.scan.html",
@@ -475,19 +503,7 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
         },
         {
             "testcase": "scan_captured_scalar_f64",
-            "callable": (
-                lambda dt=np.float64(0.1): (
-                    jax.lax.scan(
-                        lambda carry, _: (
-                            carry + jnp.asarray(dt, dtype=jnp.float64),
-                            carry + jnp.asarray(dt, dtype=jnp.float64),
-                        ),
-                        jnp.asarray(0.0, dtype=jnp.float64),
-                        xs=None,
-                        length=3,
-                    )[1]
-                )
-            ),
+            "callable": _scan_captured_scalar_f64,
             "input_shapes": [],
             "expected_output_shapes": [("JAX2ONNX_DYNAMIC_DIM_SENTINEL",)],
             "expected_output_dtypes": [jnp.float64],
@@ -515,16 +531,7 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
         },
         {
             "testcase": "scan_rank0_sequence_vectorized_f64",
-            "callable": (
-                lambda xs_vec=np.arange(4, dtype=np.float64): jax.lax.scan(
-                    lambda carry, xs: (carry + xs[0] + xs[1], carry),
-                    0.0,
-                    xs=(
-                        jnp.asarray(xs_vec, dtype=jnp.float64),
-                        jnp.full(np.shape(xs_vec), 0.1, dtype=jnp.float64),
-                    ),
-                )[1]
-            ),
+            "callable": _scan_rank0_sequence_vectorized_f64,
             "input_shapes": [],
             "expected_output_shapes": [("JAX2ONNX_DYNAMIC_DIM_SENTINEL",)],
             "expected_output_dtypes": [jnp.float64],
@@ -675,18 +682,7 @@ def _two_scans_diff_len_with_broadcast_f32() -> tuple[Any, Any]:
         },
         {
             "testcase": "scan_captured_vector_with_xs_f64",
-            "callable": (
-                lambda xs, dt=np.asarray([0.1, -0.2], dtype=np.float64): (
-                    jax.lax.scan(
-                        lambda carry, x: (
-                            carry + jnp.asarray(dt, dtype=jnp.float64) * x,
-                            carry + jnp.asarray(dt, dtype=jnp.float64) * x,
-                        ),
-                        jnp.zeros((2,), dtype=jnp.float64),
-                        xs,
-                    )[1]
-                )
-            ),
+            "callable": _scan_captured_vector_with_xs_f64,
             "input_shapes": [(5, 2)],
             "expected_output_shapes": [("JAX2ONNX_DYNAMIC_DIM_SENTINEL", 2)],
             "expected_output_dtypes": [jnp.float64],

--- a/jax2onnx/plugins/jax/lax/scatter_add.py
+++ b/jax2onnx/plugins/jax/lax/scatter_add.py
@@ -6,6 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 # Ensure cond plugin metadata dependencies are registered.
 from jax2onnx.plugins.jax.lax import cond as _cond_plugin  # noqa: F401
@@ -124,9 +125,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.zeros((5, 208, 1, 1), dtype=jnp.float64),
+                np.zeros((5, 208, 1, 1), dtype=np.float64),
                 jnp.array([4], dtype=jnp.int32),
-                jnp.ones((5, 200, 1, 1), dtype=jnp.float64),
+                np.ones((5, 200, 1, 1), dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "expected_output_shapes": [(5, 208, 1, 1)],
@@ -149,9 +150,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.zeros((3, 150, 1, 1), dtype=jnp.float64),
+                np.zeros((3, 150, 1, 1), dtype=np.float64),
                 jnp.array([7], dtype=jnp.int32),
-                jnp.ones((3, 140, 1, 1), dtype=jnp.float64),
+                np.ones((3, 140, 1, 1), dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "expected_output_shapes": [(3, 150, 1, 1)],
@@ -174,9 +175,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.zeros((8, 50, 1, 1), dtype=jnp.float64),
+                np.zeros((8, 50, 1, 1), dtype=np.float64),
                 jnp.array([2], dtype=jnp.int32),
-                jnp.ones((8, 45, 1, 1), dtype=jnp.float64),
+                np.ones((8, 45, 1, 1), dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "expected_output_shapes": [(8, 50, 1, 1)],
@@ -199,9 +200,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.zeros((5, 208, 1, 1), dtype=jnp.float64),
+                np.zeros((5, 208, 1, 1), dtype=np.float64),
                 jnp.array([0], dtype=jnp.int32),
-                jnp.ones((5, 4, 1, 1), dtype=jnp.float64),
+                np.ones((5, 4, 1, 1), dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "expected_output_shapes": [(5, 208, 1, 1)],
@@ -232,9 +233,9 @@ if TYPE_CHECKING:  # pragma: no cover
             ),
             "input_values": [
                 jnp.array(True),
-                jnp.zeros((8, 50, 1, 1), dtype=jnp.float64),
+                np.zeros((8, 50, 1, 1), dtype=np.float64),
                 jnp.array([2], dtype=jnp.int32),
-                jnp.ones((8, 45, 1, 1), dtype=jnp.float64),
+                np.ones((8, 45, 1, 1), dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "post_check_onnx_graph": EG(

--- a/jax2onnx/plugins/jax/lax/scatter_mul.py
+++ b/jax2onnx/plugins/jax/lax/scatter_mul.py
@@ -6,6 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 # Ensure cond plugin is registered when scatter_mul metadata uses it.
 from jax2onnx.plugins.jax.lax import cond as _cond_plugin  # noqa: F401
@@ -104,9 +105,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.ones((5, 208, 1, 1), dtype=jnp.float64),
+                np.ones((5, 208, 1, 1), dtype=np.float64),
                 jnp.array([4], dtype=jnp.int32),
-                jnp.full((5, 200, 1, 1), 2.0, dtype=jnp.float64),
+                np.full((5, 200, 1, 1), 2.0, dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "post_check_onnx_graph": EG(
@@ -127,9 +128,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.ones((3, 150, 1, 1), dtype=jnp.float64),
+                np.ones((3, 150, 1, 1), dtype=np.float64),
                 jnp.array([7], dtype=jnp.int32),
-                jnp.full((3, 140, 1, 1), 2.0, dtype=jnp.float64),
+                np.full((3, 140, 1, 1), 2.0, dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "post_check_onnx_graph": EG(
@@ -150,9 +151,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.ones((8, 50, 1, 1), dtype=jnp.float64),
+                np.ones((8, 50, 1, 1), dtype=np.float64),
                 jnp.array([2], dtype=jnp.int32),
-                jnp.full((8, 45, 1, 1), 2.0, dtype=jnp.float64),
+                np.full((8, 45, 1, 1), 2.0, dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "post_check_onnx_graph": EG(
@@ -173,9 +174,9 @@ if TYPE_CHECKING:  # pragma: no cover
                 ),
             ),
             "input_values": [
-                jnp.ones((5, 208, 1, 1), dtype=jnp.float64),
+                np.ones((5, 208, 1, 1), dtype=np.float64),
                 jnp.array([0], dtype=jnp.int32),
-                jnp.full((5, 4, 1, 1), 2.0, dtype=jnp.float64),
+                np.full((5, 4, 1, 1), 2.0, dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "post_check_onnx_graph": EG(
@@ -204,9 +205,9 @@ if TYPE_CHECKING:  # pragma: no cover
             ),
             "input_values": [
                 jnp.array(True),
-                jnp.ones((8, 50, 1, 1), dtype=jnp.float64),
+                np.ones((8, 50, 1, 1), dtype=np.float64),
                 jnp.array([2], dtype=jnp.int32),
-                jnp.full((8, 45, 1, 1), 2.0, dtype=jnp.float64),
+                np.full((8, 45, 1, 1), 2.0, dtype=np.float64),
             ],
             "run_only_f64_variant": True,
             "post_check_onnx_graph": EG(

--- a/jax2onnx/sandbox/issue_206.py
+++ b/jax2onnx/sandbox/issue_206.py
@@ -1,0 +1,17 @@
+# jax2onnx/sandbox/issue_206.py
+
+from jax2onnx import to_onnx
+from flax import nnx
+
+reflect_conv = nnx.Conv(
+    in_features=1,
+    out_features=1,
+    kernel_size=3,
+    padding="REFLECT",
+    rngs=nnx.Rngs(0),
+)
+
+to_onnx(
+    fn=lambda x: reflect_conv(x),
+    inputs=[("B", 128, 1)],
+)


### PR DESCRIPTION
## Summary

This PR fixes `flax.nnx.Conv` special padding handling in the NNX plugin and removes several warning-only code paths that were firing during normal `jax2onnx` imports.

The main user-facing fix is for issue #206: exporting NNX convolutions with `padding="REFLECT"` now works instead of failing during tracing. The same alignment also covers `CIRCULAR` and keeps `CAUSAL` handling consistent with upstream Flax.

## What changed

### NNX Conv special padding
- Port upstream Flax NNX special-padding behavior into the `jax2onnx` NNX conv shim
- Handle `REFLECT`, `CIRCULAR`, and `CAUSAL` by padding before binding the conv primitive
- Preserve existing fallback behavior for unsupported `input_dilation` cases rather than exporting incorrect semantics
- Keep masking / dtype handling aligned with the patched execution path

### Test coverage
- Add generated NNX conv cases for:
  - `conv_2d_reflect_padding`
  - `conv_2d_circular_padding`
  - `conv_1d_causal_padding`
- Use concrete `input_values` so the generated primitive tests also run numeric ONNX Runtime validation, instead of only shape / graph checks

### Warning cleanup
- Set an explicit Equinox `BatchNorm` mode to avoid import-time compatibility warnings
- Replace eager `jnp.float64` test fixtures in `scatter_add` / `scatter_mul` with NumPy-backed fixtures so importing plugins does not emit float64 truncation warnings
- Make `scan` float64 testcase defaults lazy so they are not materialized at import time
- Skip non-`ir.Value` placeholders during model shape finalization so nonfatal postprocessing does not warn on string placeholders

## Validation

Ran targeted checks:
- `poetry run pytest -q tests/primitives/test_nnx.py -k 'conv_2d_reflect_padding or conv_2d_circular_padding or conv_1d_causal_padding'`
- `poetry run pytest -q tests/extra_tests/scan tests/extra_tests/test_issue_57_scatter_add_broadcast_window.py`
- `poetry run ruff check ...`
- `poetry run black --check ...`

Result:
- NNX special-padding exports now pass the targeted regression coverage
- The local `issue_206` repro runs cleanly without the previous import-time warning noise
