### PR TITLE
fix: Allow dynamic input shapes when exporting nnx.Conv with padding="REPEAT"

### DIFF
--- a/jax2onnx/plugins/jax/lax/slice.py
+++ b/jax2onnx/plugins/jax/lax/slice.py
@@ -16,6 +16,7 @@ from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
+from jax2onnx.utils.shape_poly import dim_expr_constant_value
 
 if TYPE_CHECKING:
     pass
@@ -96,15 +97,29 @@ class SlicePlugin(PrimitiveLeafPlugin):
 
         axes = tuple(range(len(starts)))
 
-        starts_val = _const_i64(ctx, starts, "slice_starts")
+        def _normalize_index(value: object) -> object:
+            if isinstance(value, (int, np.integer)):
+                return int(value)
+            const_val = dim_expr_constant_value(value)
+            if const_val is not None:
+                return const_val
+            return value
 
-        def _coerce_limit(val: object) -> int:
-            if isinstance(val, (int, np.integer)):
-                return int(val)
-            return np.iinfo(np.int64).max
+        def _index_vector(values: tuple[object, ...], name: str) -> ir.Value:
+            normalized_values = [_normalize_index(value) for value in values]
+            if all(isinstance(value, int) for value in normalized_values):
+                return _const_i64(ctx, normalized_values, name)
+            dim_expr_lowerer = getattr(ctx, "dim_expr_lowerer", None)
+            if dim_expr_lowerer is None:
+                raise ValueError(
+                    f"slice lowering requires ctx.dim_expr_lowerer for symbolic {name}"
+                )
+            return dim_expr_lowerer(normalized_values)
 
-        normalized_limits = tuple(_coerce_limit(v) for v in limits)
-        limits_val = _const_i64(ctx, normalized_limits, "slice_limits")
+        starts_val = _index_vector(tuple(starts), "slice_starts")
+
+        normalized_limits = tuple(_normalize_index(v) for v in limits)
+        limits_val = _index_vector(normalized_limits, "slice_limits")
         axes_val = _const_i64(ctx, axes, "slice_axes")
 
         def _axis0_extent_from_slice_spec() -> int | None:

--- a/tests/extra_tests/test_issue_210_dynamic_reflect_padding.py
+++ b/tests/extra_tests/test_issue_210_dynamic_reflect_padding.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from jax2onnx import to_onnx
+
+
+def test_issue_210_nnx_conv_reflect_padding_exports_with_symbolic_length() -> None:
+    conv = nnx.Conv(
+        in_features=1,
+        out_features=1,
+        kernel_size=3,
+        padding="REFLECT",
+        rngs=nnx.Rngs(0),
+    )
+    length = jax.export.symbolic_shape("N", constraints=("N >= 2",))
+
+    model = to_onnx(
+        fn=lambda x: conv(x[None, :, None]),
+        inputs=[jax.ShapeDtypeStruct(length, dtype=jnp.float32)],
+        model_name="issue_210_dynamic_reflect_padding",
+    )
+
+    assert model is not None


### PR DESCRIPTION
This PR adds a regression test for #210 and attempts a fix. To ensure transparency: **All code was written by Codex** (with gpt-5.4 xhigh). I ensured that the agent is reasonably familiar with the repo and added the test before writing the fix, but I would not consider myself familiar enough with the codebase to guarantee that the approach is fully correct. Additionally, I confirmed that the fixed version was able to successfully export my model with the affected `nnx.Conv` modules. Since this is only touching a single file of the implementation, maybe it's worth reviewing?

Codex-generated summary below:

---

## Summary

- Fix `nnx.Conv(..., padding="REFLECT")` export when the convolution dimension is symbolic.
- Add a regression test for issue `#210`.

## Problem

Issue `#210` reports that exporting an `nnx.Conv` with `padding="REFLECT"` fails when the input length is symbolic, even though the same model works with fixed input sizes.

The failing path goes through the reflect-padding helper emitted by JAX, which contains `lax.slice` operations with symbolic bounds such as `N`, `N + 1`, and `N - 1`. The current `lax.slice` lowering tried to coerce those bounds into constant `int64` initializers via `np.asarray(..., dtype=np.int64)`, which raises `InconclusiveDimensionOperation` for symbolic dimensions.

## Fix

- Keep the existing constant fast path for ordinary static slice bounds.
- Normalize slice indices so constant-looking symbolic values still fold to plain Python ints when possible.
- Lower non-constant symbolic `start_indices` and `limit_indices` through `ctx.dim_expr_lowerer` instead of forcing them into initializers.
- Leave the rest of the `Slice` lowering behavior unchanged, including axis handling and output metadata stamping.

## Regression Coverage

- Add `tests/extra_tests/test_issue_210_dynamic_reflect_padding.py`.
- The new test reproduces the minimal issue pattern and asserts that `to_onnx(...)` succeeds for `nnx.Conv(..., padding="REFLECT")` with a symbolic length constraint `N >= 2`.

## Validation

- `poetry run pytest -q tests/extra_tests/test_issue_210_dynamic_reflect_padding.py`
- `poetry run pytest -q tests/primitives/test_nnx.py -k conv_2d_reflect_padding`
- `poetry run pytest -q tests/primitives/test_lax.py -k slice_test1`
- `poetry run python scripts/generate_tests.py`
- `poetry run pytest -n auto --dist=loadscope tests/primitives tests/extra_tests tests/test_gpt_oss_components.py --ignore=tests/extra_tests/examples`

## Baseline Status

The reduced local suite still has the same three pre-existing failures as before this change:

- `tests/primitives/test_jnp.py::Test_nanmedian::test_jnp_nanmedian_basic`
- `tests/primitives/test_jnp.py::Test_nanquantile::test_jnp_nanquantile_basic`
- `tests/primitives/test_jnp.py::Test_nanpercentile::test_jnp_nanpercentile_basic`

The post-change reduced suite result was:

- `2894 passed`
- `3 failed`

No new failures were introduced in that local baseline run. The heavier integration/example suites were not rerun locally.
