### PR TITLE
[codex] Add JAX 0.10 Opset 27 range and resize coverage

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -14,7 +14,17 @@
 * Continue targeted coverage work for JAX, Flax NNX/Linen, Equinox, SotA
   examples, and physics/simulation use cases.
 
+## Upcoming Version
 
+### **jax2onnx 0.14.1**
+
+* **Add targeted Opset 27 coverage:** Preserve the Opset 23 default while using
+  native FP16/BF16 `Range` for `opset=27` exports and keeping older exports on
+  the cast fallback; cover new JAX 0.10 resize methods where the ONNX mapping is
+  exact.
+* **Refresh the validation stack:** Update the upcoming documented runtime
+  stack to JAX `0.10.2`, Equinox `0.13.8`, ONNX `1.22.0`, ONNX Runtime
+  `1.27.0`, and the matching `onnxruntime-web` versions for Web validation.
 
 ## Current Version
 

--- a/jax2onnx/plugins/__init__.py
+++ b/jax2onnx/plugins/__init__.py
@@ -1,1 +1,5 @@
 # jax2onnx/plugins/__init__.py
+
+from jax2onnx.plugins.jax._batching_compat import ensure_batching_not_mapped_attr
+
+ensure_batching_not_mapped_attr()

--- a/jax2onnx/plugins/examples/maxtext/maxtext_models.py
+++ b/jax2onnx/plugins/examples/maxtext/maxtext_models.py
@@ -1405,28 +1405,30 @@ def _patch_random_normal_to_zero() -> callable:
 
     orig_normal = jax.random.normal
     orig_truncated = jax.random.truncated_normal
-    orig_module_normal = _random.normal
-    orig_module_truncated = _random.truncated_normal
-    orig_internal_normal = _random._normal
-    orig_internal_normal_real = _random._normal_real
-    orig_internal_truncated = _random._truncated_normal
+    missing = object()
+    random_module_patches = (
+        ("normal", _zero_normal),
+        ("truncated_normal", _zero_truncated_normal),
+        ("_normal", _zero_normal),
+        ("_normal_real", _zero_normal_real),
+        ("_truncated_normal", _zero_truncated_normal),
+    )
+    random_module_originals: list[tuple[str, object]] = []
 
     jax.random.normal = _zero_normal
     jax.random.truncated_normal = _zero_truncated_normal
-    _random.normal = _zero_normal
-    _random.truncated_normal = _zero_truncated_normal
-    _random._normal = _zero_normal
-    _random._normal_real = _zero_normal_real
-    _random._truncated_normal = _zero_truncated_normal
+    for name, replacement in random_module_patches:
+        original = getattr(_random, name, missing)
+        if original is missing:
+            continue
+        random_module_originals.append((name, original))
+        setattr(_random, name, replacement)
 
     def _restore() -> None:
         jax.random.normal = orig_normal
         jax.random.truncated_normal = orig_truncated
-        _random.normal = orig_module_normal
-        _random.truncated_normal = orig_module_truncated
-        _random._normal = orig_internal_normal
-        _random._normal_real = orig_internal_normal_real
-        _random._truncated_normal = orig_internal_truncated
+        for name, original in random_module_originals:
+            setattr(_random, name, original)
 
     return _restore
 

--- a/jax2onnx/plugins/jax/_batching_compat.py
+++ b/jax2onnx/plugins/jax/_batching_compat.py
@@ -1,0 +1,22 @@
+# jax2onnx/plugins/jax/_batching_compat.py
+
+"""Compatibility helpers for JAX batching internals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jax.interpreters import batching
+
+
+def ensure_batching_not_mapped_attr() -> Any:
+    """Expose the legacy ``batching.not_mapped`` name when JAX uses ``None``."""
+
+    try:
+        return batching.not_mapped
+    except AttributeError:
+        setattr(batching, "not_mapped", None)
+        return None
+
+
+NOT_MAPPED: Any = ensure_batching_not_mapped_attr()

--- a/jax2onnx/plugins/jax/_batching_utils.py
+++ b/jax2onnx/plugins/jax/_batching_utils.py
@@ -8,6 +8,10 @@ import numpy as np
 from jax import lax
 from jax.interpreters import batching
 
+from jax2onnx.plugins.jax._batching_compat import ensure_batching_not_mapped_attr
+
+ensure_batching_not_mapped_attr()
+
 
 def _resolve_definitely_equal_shape() -> Callable[[Any, Any], bool]:
     try:  # Prefer the internal helper when available (moved in newer JAX versions).

--- a/jax2onnx/plugins/jax/image/resize.py
+++ b/jax2onnx/plugins/jax/image/resize.py
@@ -40,24 +40,29 @@ def _normalize_method(method: str | jimage.ResizeMethod) -> str:
 
 
 def _canonical_method(method: str) -> str:
+    method = method.replace("_", "-")
     alias_map = {
         "bilinear": "linear",
         "trilinear": "linear",
         "triangle": "linear",
         "bicubic": "cubic",
         "tricubic": "cubic",
+        "cubic-pytorch": "cubic_pytorch",
+        "bicubic-pytorch": "cubic_pytorch",
     }
     return alias_map.get(method, method)
 
 
-def _compute_exact_linear_resize_weights(
+def _compute_exact_resize_weights(
     *,
     input_shape: Sequence[int],
     output_shape: Sequence[int],
+    method: str,
+    antialias: bool,
     dtype: np.dtype[Any],
     precision: object,
 ) -> np.ndarray:
-    """Build an exact static linear resize matrix from the original JAX op."""
+    """Build an exact static resize matrix from the original JAX op."""
     try:
         from jax._src.image.scale import _resize as jax_resize_impl  # noqa: PLC0415
     except Exception:
@@ -83,14 +88,144 @@ def _compute_exact_linear_resize_weights(
     input_size = int(np.prod(input_shape_tuple, dtype=np.int64))
     output_size = int(np.prod(output_shape_tuple, dtype=np.int64))
     basis = np.eye(input_size, dtype=dtype).reshape((input_size,) + input_shape_tuple)
+    jax_method = "cubic-pytorch" if method == "cubic_pytorch" else method
 
     resized_basis = jax.vmap(
-        lambda x: jax_resize_impl(x, output_shape_tuple, "linear", False, precision)
+        lambda x: jax_resize_impl(
+            x, output_shape_tuple, jax_method, antialias, precision
+        )
     )(basis)
     return cast(
         np.ndarray[Any, np.dtype[Any]],
         np.asarray(resized_basis, dtype=dtype).reshape((input_size, output_size)),
     )
+
+
+def _resize_weight_dtype_enum(dtype: np.dtype[Any]) -> ir.DataType:
+    if dtype == np.float64:
+        return ir.DataType.DOUBLE
+    if dtype == np.float16:
+        return ir.DataType.FLOAT16
+    if dtype.name == "bfloat16":
+        return ir.DataType.BFLOAT16
+    return ir.DataType.FLOAT
+
+
+def _emit_exact_static_resize(
+    ctx: LoweringContextProtocol,
+    *,
+    image_var: Any,
+    image_val: ir.Value,
+    image_dtype: ir.DataType | None,
+    output_shape: Sequence[int],
+    method: str,
+    antialias: bool,
+    precision: object,
+    out_var: Any,
+    name_prefix: str,
+) -> bool:
+    input_shape = tuple(getattr(getattr(image_var, "aval", None), "shape", ()))
+    if len(input_shape) != len(output_shape):
+        return False
+
+    input_shape_ints: list[int] = []
+    for dim in input_shape:
+        normalized = _normalized_dim(dim)
+        if normalized is None or normalized <= 0:
+            return False
+        input_shape_ints.append(normalized)
+
+    input_size = int(np.prod(tuple(input_shape_ints), dtype=np.int64))
+    output_size = int(np.prod(tuple(output_shape), dtype=np.int64))
+    if input_size * output_size > _MAX_EXACT_LINEAR_OPSET9_WEIGHTS:
+        return False
+
+    input_np_dtype = np.dtype(
+        getattr(getattr(image_var, "aval", None), "dtype", np.float32)
+    )
+    weight_dtype = (
+        input_np_dtype
+        if np.issubdtype(input_np_dtype, np.floating)
+        else np.dtype(np.float32)
+    )
+    weights = _compute_exact_resize_weights(
+        input_shape=tuple(input_shape_ints),
+        output_shape=output_shape,
+        method=method,
+        antialias=antialias,
+        dtype=weight_dtype,
+        precision=precision,
+    )
+    weight_dtype_enum = _resize_weight_dtype_enum(weight_dtype)
+
+    flat_shape = _const_i64(
+        ctx,
+        np.asarray([input_size], dtype=np.int64),
+        ctx.fresh_name(f"{name_prefix}_flat_shape"),
+    )
+    flat_val = cast(
+        ir.Value,
+        ctx.builder.Reshape(
+            image_val,
+            flat_shape,
+            _outputs=[ctx.fresh_name(f"{name_prefix}_flattened")],
+        ),
+    )
+    if image_dtype is not None:
+        flat_val.type = ir.TensorType(image_dtype)
+    _stamp_type_and_shape(flat_val, (input_size,))
+    _ensure_value_metadata(ctx, flat_val)
+
+    matmul_input: ir.Value = flat_val
+    if input_np_dtype != weight_dtype:
+        matmul_input = cast(
+            ir.Value,
+            ctx.builder.Cast(
+                flat_val,
+                _outputs=[ctx.fresh_name(f"{name_prefix}_cast")],
+                to=int(weight_dtype_enum.value),
+            ),
+        )
+        matmul_input.type = ir.TensorType(weight_dtype_enum)
+        _stamp_type_and_shape(matmul_input, (input_size,))
+        _ensure_value_metadata(ctx, matmul_input)
+
+    weights_const = ctx.builder.add_initializer_from_array(
+        name=ctx.fresh_name(f"{name_prefix}_weights"),
+        array=weights,
+    )
+    matmul_out = cast(
+        ir.Value,
+        ctx.builder.MatMul(
+            matmul_input,
+            weights_const,
+            _outputs=[ctx.fresh_name(f"{name_prefix}_flat_out")],
+        ),
+    )
+    matmul_out.type = ir.TensorType(weight_dtype_enum)
+    _stamp_type_and_shape(matmul_out, (output_size,))
+    _ensure_value_metadata(ctx, matmul_out)
+
+    out_shape_const = _const_i64(
+        ctx,
+        np.asarray(output_shape, dtype=np.int64),
+        ctx.fresh_name(f"{name_prefix}_out_shape"),
+    )
+    exact_out = cast(
+        ir.Value,
+        ctx.builder.Reshape(
+            matmul_out,
+            out_shape_const,
+            _outputs=[ctx.fresh_name(f"{name_prefix}_out")],
+        ),
+    )
+    exact_out.type = ir.TensorType(weight_dtype_enum)
+    _stamp_type_and_shape(
+        exact_out, tuple(_normalized_dim(dim) for dim in output_shape)
+    )
+    _ensure_value_metadata(ctx, exact_out)
+    ctx.bind_value_for_var(out_var, exact_out)
+    return True
 
 
 @register_primitive(
@@ -176,6 +311,32 @@ def _compute_exact_linear_resize_weights(
             "post_check_onnx_graph": EG(["Upsample"], no_unused_inputs=True),
             "run_only_f32_variant": True,
         },
+        {
+            "testcase": "resize_area_static_exact",
+            "callable": lambda x: jimage.resize(
+                x, (2, 2), method="area", antialias=False
+            ),
+            "input_shapes": [(4, 4)],
+            "expected_output_shapes": [(2, 2)],
+            "post_check_onnx_graph": EG(
+                ["Reshape:16 -> MatMul:4 -> Reshape:2x2"],
+                no_unused_inputs=True,
+            ),
+            "run_only_f32_variant": True,
+        },
+        {
+            "testcase": "resize_cubic_pytorch_static_exact",
+            "callable": lambda x: jimage.resize(
+                x, (3, 5), method="cubic-pytorch", antialias=False
+            ),
+            "input_shapes": [(2, 2)],
+            "expected_output_shapes": [(3, 5)],
+            "post_check_onnx_graph": EG(
+                ["Reshape:4 -> MatMul:15 -> Reshape:3x5"],
+                no_unused_inputs=True,
+            ),
+            "run_only_f32_variant": True,
+        },
     ],
 )
 class ImageResizePlugin(PrimitiveLeafPlugin):
@@ -186,7 +347,11 @@ class ImageResizePlugin(PrimitiveLeafPlugin):
         "nearest": "nearest",
         "linear": "linear",
         "cubic": "cubic",
+        "cubic_pytorch": "cubic",
     }
+    _STATIC_EXACT_METHODS: ClassVar[frozenset[str]] = frozenset(
+        {"area", "cubic_pytorch"}
+    )
 
     @staticmethod
     def abstract_eval(
@@ -217,20 +382,42 @@ class ImageResizePlugin(PrimitiveLeafPlugin):
         antialias = bool(params.get("antialias", False))
         precision = params.get("precision", None)
 
-        if method not in self._SUPPORTED_MODES:
+        if (
+            method not in self._SUPPORTED_MODES
+            and method not in self._STATIC_EXACT_METHODS
+        ):
             raise NotImplementedError(f"resize method '{method}' is not supported")
         if method == "nearest":
             antialias = False
             precision = None
-        if antialias:
-            raise NotImplementedError("resize with antialias=True is not supported yet")
-        if precision not in (None, jax.lax.Precision.DEFAULT):
-            raise NotImplementedError("resize precision overrides are not supported")
 
         image_val = ctx.get_value_for_var(
             image_var, name_hint=ctx.fresh_name("resize_input")
         )
         image_dtype = getattr(getattr(image_val, "type", None), "dtype", None)
+
+        if method in self._STATIC_EXACT_METHODS and _emit_exact_static_resize(
+            ctx,
+            image_var=image_var,
+            image_val=image_val,
+            image_dtype=image_dtype,
+            output_shape=shape,
+            method=method,
+            antialias=antialias,
+            precision=precision,
+            out_var=out_var,
+            name_prefix=f"resize_{method}",
+        ):
+            return
+        if method == "area":
+            raise NotImplementedError(
+                "resize method 'area' requires static positive dimensions small "
+                "enough for exact matrix lowering"
+            )
+        if antialias:
+            raise NotImplementedError("resize with antialias=True is not supported yet")
+        if precision not in (None, jax.lax.Precision.DEFAULT):
+            raise NotImplementedError("resize precision overrides are not supported")
 
         opset = int(getattr(ctx.builder, "opset", 21))
         if opset <= 9:
@@ -266,9 +453,11 @@ class ImageResizePlugin(PrimitiveLeafPlugin):
                         if np.issubdtype(input_np_dtype, np.floating)
                         else np.dtype(np.float32)
                     )
-                    weights = _compute_exact_linear_resize_weights(
+                    weights = _compute_exact_resize_weights(
                         input_shape=input_shape_ints,
                         output_shape=shape,
+                        method="linear",
+                        antialias=False,
                         dtype=weight_dtype,
                         precision=precision,
                     )
@@ -384,12 +573,16 @@ class ImageResizePlugin(PrimitiveLeafPlugin):
 
         resize_kwargs: dict[str, object] = {
             "mode": self._SUPPORTED_MODES[method],
-            "coordinate_transformation_mode": "half_pixel",
+            "coordinate_transformation_mode": (
+                "pytorch_half_pixel" if method == "cubic_pytorch" else "half_pixel"
+            ),
         }
         if method == "nearest":
             resize_kwargs["nearest_mode"] = "round_prefer_floor"
-        if method == "cubic":
-            resize_kwargs["cubic_coeff_a"] = -0.5
+        if method in {"cubic", "cubic_pytorch"}:
+            resize_kwargs["cubic_coeff_a"] = (
+                -0.75 if method == "cubic_pytorch" else -0.5
+            )
 
         resize_out = cast(
             ir.Value,

--- a/jax2onnx/plugins/jax/lax/iota.py
+++ b/jax2onnx/plugins/jax/lax/iota.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Final, cast
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
 
@@ -36,9 +37,25 @@ _SUPPORTED_IOTA_DTYPES: Final[frozenset[np.dtype[Any]]] = frozenset(
         np.dtype(np.uint64),
         np.dtype(np.float32),
         np.dtype(np.float64),
+        np.dtype(np.float16),
+        np.dtype(jnp.bfloat16),
         np.dtype(np.bool_),
     }
 )
+_OPSET27_NATIVE_RANGE_DTYPES: Final[frozenset[np.dtype[Any]]] = frozenset(
+    {
+        np.dtype(np.float16),
+        np.dtype(jnp.bfloat16),
+    }
+)
+
+
+def _const_scalar_of_dtype(
+    ctx: LoweringContextProtocol,
+    value: int | float,
+    dtype: np.dtype[Any],
+) -> ir.Value:
+    return ctx.bind_const_for_var(object(), np.asarray(value, dtype=dtype))
 
 
 @register_primitive(
@@ -71,6 +88,61 @@ _SUPPORTED_IOTA_DTYPES: Final[frozenset[np.dtype[Any]]] = frozenset(
                 ["Range:10 -> Cast:10"],
                 no_unused_inputs=True,
             ),
+        },
+        {
+            "testcase": "iota_bfloat16_opset23_cast_fallback",
+            "callable": lambda: jax.lax.iota(jnp.bfloat16, 5),
+            "input_shapes": [],
+            "opset_version": 23,
+            "expected_output_dtypes": [jnp.bfloat16],
+            "post_check_onnx_graph": EG(
+                ["Range:5 -> Cast:5"],
+                no_unused_inputs=True,
+            ),
+            "skip_numeric_validation": True,
+            "run_only_f32_variant": True,
+        },
+        {
+            "testcase": "iota_bfloat16_opset27_native_range",
+            "callable": lambda: jax.lax.iota(jnp.bfloat16, 5),
+            "input_shapes": [],
+            "opset_version": 27,
+            "expected_output_dtypes": [jnp.bfloat16],
+            "post_check_onnx_graph": EG(
+                [
+                    (
+                        "Range:5",
+                        {
+                            "counts": {"Range": 1},
+                            "must_absent": ["Cast"],
+                        },
+                    )
+                ],
+                no_unused_inputs=True,
+            ),
+            "skip_numeric_validation": True,
+            "run_only_f32_variant": True,
+        },
+        {
+            "testcase": "iota_float16_opset27_native_range",
+            "callable": lambda: jax.lax.iota(np.float16, 5),
+            "input_shapes": [],
+            "opset_version": 27,
+            "expected_output_dtypes": [np.float16],
+            "post_check_onnx_graph": EG(
+                [
+                    (
+                        "Range:5",
+                        {
+                            "counts": {"Range": 1},
+                            "must_absent": ["Cast"],
+                        },
+                    )
+                ],
+                no_unused_inputs=True,
+            ),
+            "skip_numeric_validation": True,
+            "run_only_f32_variant": True,
         },
         {
             "testcase": "iota_uint8",
@@ -118,26 +190,54 @@ class IotaPlugin(PrimitiveLeafPlugin):
                 f"iota dimension {dimension} out of range for shape {shape}"
             )
 
+        if dtype not in _SUPPORTED_IOTA_DTYPES:
+            raise TypeError(f"Unsupported dtype for lax.iota: {dtype}")
+        target_dtype = numpy_dtype_to_ir(dtype)
+        use_native_range_dtype = (
+            int(getattr(builder, "opset", 0) or 0) >= 27
+            and dtype in _OPSET27_NATIVE_RANGE_DTYPES
+        )
+        range_dtype = target_dtype if use_native_range_dtype else ir.DataType.INT64
+
         dim_extent = shape[dimension]
-        limit_vec = _lower_i64_vector(ctx, [dim_extent], "iota_limit_vec")
-        squeeze_axes = _const_i64(
-            ctx, np.asarray([0], dtype=np.int64), "iota_limit_squeeze_axes"
-        )
-        limit = cast(
-            ir.Value,
-            builder.Squeeze(
-                limit_vec,
-                squeeze_axes,
-                _outputs=[ctx.fresh_name("iota_limit")],
-            ),
-        )
-        limit.type = ir.TensorType(ir.DataType.INT64)
-        _stamp_type_and_shape(limit, ())
-        _ensure_value_metadata(ctx, limit)
+        if use_native_range_dtype and isinstance(dim_extent, (int, np.integer)):
+            limit = _const_scalar_of_dtype(ctx, int(dim_extent), dtype)
+        else:
+            limit_vec = _lower_i64_vector(ctx, [dim_extent], "iota_limit_vec")
+            squeeze_axes = _const_i64(
+                ctx, np.asarray([0], dtype=np.int64), "iota_limit_squeeze_axes"
+            )
+            limit = cast(
+                ir.Value,
+                builder.Squeeze(
+                    limit_vec,
+                    squeeze_axes,
+                    _outputs=[ctx.fresh_name("iota_limit")],
+                ),
+            )
+            limit.type = ir.TensorType(ir.DataType.INT64)
+            _stamp_type_and_shape(limit, ())
+            _ensure_value_metadata(ctx, limit)
+            if use_native_range_dtype:
+                limit = cast(
+                    ir.Value,
+                    builder.Cast(
+                        limit,
+                        _outputs=[ctx.fresh_name("iota_limit_cast")],
+                        to=int(target_dtype.value),
+                    ),
+                )
+                limit.type = ir.TensorType(target_dtype)
+                _stamp_type_and_shape(limit, ())
+                _ensure_value_metadata(ctx, limit)
 
         # Build the 1-D range along the chosen axis.
-        start = _scalar_i64(ctx, 0, "iota_start")
-        delta = _scalar_i64(ctx, 1, "iota_delta")
+        if use_native_range_dtype:
+            start = _const_scalar_of_dtype(ctx, 0, dtype)
+            delta = _const_scalar_of_dtype(ctx, 1, dtype)
+        else:
+            start = _scalar_i64(ctx, 0, "iota_start")
+            delta = _scalar_i64(ctx, 1, "iota_delta")
 
         range_out = cast(
             ir.Value,
@@ -148,7 +248,7 @@ class IotaPlugin(PrimitiveLeafPlugin):
                 _outputs=[ctx.fresh_name("iota_range")],
             ),
         )
-        range_out.type = ir.TensorType(ir.DataType.INT64)
+        range_out.type = ir.TensorType(range_dtype)
         _stamp_type_and_shape(range_out, (dim_extent,))
         _ensure_value_metadata(ctx, range_out)
 
@@ -171,7 +271,7 @@ class IotaPlugin(PrimitiveLeafPlugin):
                         _outputs=[ctx.fresh_name("iota_unsq")],
                     ),
                 )
-                current_unsq.type = ir.TensorType(ir.DataType.INT64)
+                current_unsq.type = ir.TensorType(range_dtype)
                 _stamp_type_and_shape(current_unsq, tuple(unsq_shape))
                 _ensure_value_metadata(ctx, current_unsq)
                 current = current_unsq
@@ -185,16 +285,12 @@ class IotaPlugin(PrimitiveLeafPlugin):
                     _outputs=[ctx.fresh_name("iota_expanded")],
                 ),
             )
-            expanded.type = ir.TensorType(ir.DataType.INT64)
+            expanded.type = ir.TensorType(range_dtype)
             _stamp_type_and_shape(expanded, tuple(shape))
             _ensure_value_metadata(ctx, expanded)
             current = expanded
 
-        if dtype not in _SUPPORTED_IOTA_DTYPES:
-            raise TypeError(f"Unsupported dtype for lax.iota: {dtype}")
-        target_dtype = numpy_dtype_to_ir(dtype)
-
-        if target_dtype != ir.DataType.INT64:
+        if target_dtype != range_dtype:
             cast_out = cast(
                 ir.Value,
                 builder.Cast(

--- a/jax2onnx/plugins/jax/numpy/arange.py
+++ b/jax2onnx/plugins/jax/numpy/arange.py
@@ -22,6 +22,12 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 
 _DYNAMIC_DIM_LABEL: Final[str] = "JAX2ONNX_DYNAMIC_DIM_SENTINEL"
 _JNP_ARANGE_ORIG: Final = jnp.arange
+_OPSET27_NATIVE_RANGE_DTYPES: Final[frozenset[np.dtype[Any]]] = frozenset(
+    {
+        np.dtype(np.float16),
+        np.dtype(jnp.bfloat16),
+    }
+)
 
 
 def _resolve_symbolic_dynamic_dim() -> Any | None:
@@ -658,6 +664,20 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
             avals, dtype_param, enable_x64
         )
         target_enum: ir.DataType = numpy_dtype_to_ir(result_dtype)
+        builder = getattr(ctx, "builder", None)
+        if builder is None:
+            raise AttributeError("IR build context missing builder for arange lowering")
+        use_native_range_dtype = (
+            int(getattr(builder, "opset", 0) or 0) >= 27
+            and result_dtype in _OPSET27_NATIVE_RANGE_DTYPES
+        )
+        range_dtype = (
+            result_dtype
+            if result_dtype not in _OPSET27_NATIVE_RANGE_DTYPES
+            or use_native_range_dtype
+            else np.dtype(np.float32)
+        )
+        range_enum: ir.DataType = numpy_dtype_to_ir(range_dtype)
 
         literal_args: list[float | int] | None = []
         input_vals: list[ir.Value] = []
@@ -665,10 +685,10 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
             val = ctx.get_value_for_var(
                 var,
                 name_hint=ctx.fresh_name("arange_arg"),
-                prefer_np_dtype=result_dtype,
+                prefer_np_dtype=range_dtype,
             )
             input_vals.append(
-                _maybe_cast_value(ctx, val, target_enum, f"arange_cast_{idx}")
+                _maybe_cast_value(ctx, val, range_enum, f"arange_cast_{idx}")
             )
             if literal_args is not None and isinstance(var, JaxLiteral):
                 literal_value = cast(float | int, np.asarray(var.val).item())
@@ -677,7 +697,7 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
                 literal_args = None
 
         def _const(value: float | int, tag: str) -> ir.Value:
-            arr = np.asarray(value, dtype=result_dtype)
+            arr = np.asarray(value, dtype=range_dtype)
             const_value: ir.Value = ctx.bind_const_for_var(object(), arr)
             return const_value
 
@@ -695,13 +715,9 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
                 f"jnp.arange lowering expects 1 to 3 inputs, got {len(input_vals)}"
             )
 
-        start_val = _maybe_cast_value(ctx, start_val, target_enum, "arange_start")
-        limit_val = _maybe_cast_value(ctx, limit_val, target_enum, "arange_limit")
-        delta_val = _maybe_cast_value(ctx, delta_val, target_enum, "arange_delta")
-
-        builder = getattr(ctx, "builder", None)
-        if builder is None:
-            raise AttributeError("IR build context missing builder for arange lowering")
+        start_val = _maybe_cast_value(ctx, start_val, range_enum, "arange_start")
+        limit_val = _maybe_cast_value(ctx, limit_val, range_enum, "arange_limit")
+        delta_val = _maybe_cast_value(ctx, delta_val, range_enum, "arange_delta")
 
         out_var = eqn.outvars[0]
         out_spec = ctx.get_value_for_var(
@@ -710,13 +726,16 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
             prefer_np_dtype=result_dtype,
         )
         out_name = getattr(out_spec, "name", None) or ctx.fresh_name("arange_out")
+        range_output_name = (
+            out_name if range_enum == target_enum else ctx.fresh_name("arange_range")
+        )
         result = builder.Range(
             start_val,
             limit_val,
             delta_val,
-            _outputs=[out_name],
+            _outputs=[range_output_name],
         )
-        result.type = ir.TensorType(target_enum)
+        result.type = ir.TensorType(range_enum)
 
         length_hint: int | None = None
         if literal_args is not None:
@@ -745,10 +764,25 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
 
         _stamp_type_and_shape(result, final_shape)
         _ensure_value_metadata(ctx, result)
+
+        final_result = result
+        if range_enum != target_enum:
+            final_result = cast(
+                ir.Value,
+                builder.Cast(
+                    result,
+                    _outputs=[out_name],
+                    to=int(target_enum.value),
+                ),
+            )
+            final_result.type = ir.TensorType(target_enum)
+            _stamp_type_and_shape(final_result, final_shape)
+            _ensure_value_metadata(ctx, final_result)
+
         bind_value = getattr(ctx, "bind_value_for_var", None)
         if not callable(bind_value):
             raise AttributeError("IR build context missing bind_value_for_var")
-        bind_value(out_var, result)
+        bind_value(out_var, final_result)
 
     @classmethod
     def binding_specs(cls) -> list[AssignSpec | MonkeyPatchSpec]:

--- a/jax2onnx/plugins/plugin_system.py
+++ b/jax2onnx/plugins/plugin_system.py
@@ -39,6 +39,7 @@ from jax.interpreters import batching
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec, apply_patches
 from jax2onnx.plugins.jax._autodiff_utils import backfill_missing_transpose_rules
+from jax2onnx.plugins.jax._batching_compat import ensure_batching_not_mapped_attr
 from jax2onnx.converter.function_scope import FunctionScope, FunctionKey
 from jax2onnx.converter.lowering_dispatch import (
     lower_jaxpr_with_plugins,
@@ -52,6 +53,8 @@ from jax2onnx.converter.typing_support import (
 )
 
 logger: logging.Logger = logging.getLogger("jax2onnx.plugins.plugin_system")
+
+ensure_batching_not_mapped_attr()
 
 # ------------------------------------------------------------------------------
 # Registries and state

--- a/tests/extra_tests/framework/test_do_not_skip_numeric_validation.py
+++ b/tests/extra_tests/framework/test_do_not_skip_numeric_validation.py
@@ -109,6 +109,13 @@ _ALLOWED_SKIP_CASES: set[tuple[str, str, str]] = {
     # JAX 0.10 removed the legacy a_min/a_max keyword spelling, so this testcase
     # only verifies converter/plugin compatibility during export.
     ("primitives.jnp", "clip", "clip_keyword_legacy_a_min_a_max_aliases"),
+    # ORT/NumPy cannot run the BF16 zero-input parity path in the generated
+    # numeric harness yet; keep structural and dtype coverage enabled.
+    ("primitives.lax", "iota", "iota_bfloat16_opset23_cast_fallback"),
+    # ORT 1.27 does not execute ai.onnx opset 27 models yet; these cases verify
+    # native Range structure and output dtype while runtime support catches up.
+    ("primitives.lax", "iota", "iota_bfloat16_opset27_native_range"),
+    ("primitives.lax", "iota", "iota_float16_opset27_native_range"),
 }
 _ALLOWED_SKIP_CONTEXTS: set[str] = {
     "examples.maxtext",  # ORT cannot execute MaxText graphs yet.

--- a/tests/extra_tests/test_opset27_range_and_resize.py
+++ b/tests/extra_tests/test_opset27_range_and_resize.py
@@ -1,0 +1,91 @@
+# tests/extra_tests/test_opset27_range_and_resize.py
+
+from __future__ import annotations
+
+import jax
+import jax.image as jimage
+import jax.numpy as jnp
+import numpy as np
+import onnx
+from onnx import TensorProto
+
+from jax2onnx.user_interface import to_onnx
+
+
+def _node_types(model: onnx.ModelProto) -> list[str]:
+    return [node.op_type for node in model.graph.node]
+
+
+def test_iota_bfloat16_opset23_keeps_cast_fallback() -> None:
+    model = to_onnx(lambda: jax.lax.iota(jnp.bfloat16, 5), [], opset=23)
+
+    onnx.checker.check_model(model)
+    ops = _node_types(model)
+    assert "Range" in ops
+    assert "Cast" in ops
+    assert model.graph.output[0].type.tensor_type.elem_type == TensorProto.BFLOAT16
+
+
+def test_iota_bfloat16_opset27_uses_native_range_dtype() -> None:
+    model = to_onnx(lambda: jax.lax.iota(jnp.bfloat16, 5), [], opset=27)
+
+    onnx.checker.check_model(model)
+    ops = _node_types(model)
+    assert "Range" in ops
+    assert "Cast" not in ops
+    assert model.graph.output[0].type.tensor_type.elem_type == TensorProto.BFLOAT16
+
+
+def test_dynamic_arange_bfloat16_opset23_casts_after_range() -> None:
+    model = to_onnx(
+        lambda stop: jnp.arange(stop, dtype=jnp.bfloat16),
+        [jax.ShapeDtypeStruct((), jnp.float32)],
+        opset=23,
+    )
+
+    onnx.checker.check_model(model)
+    assert [node.op_type for node in model.graph.node[-2:]] == ["Range", "Cast"]
+    assert model.graph.output[0].name == model.graph.node[-1].output[0]
+    assert model.graph.output[0].type.tensor_type.elem_type == TensorProto.BFLOAT16
+
+
+def test_dynamic_arange_bfloat16_opset27_range_is_graph_output() -> None:
+    model = to_onnx(
+        lambda stop: jnp.arange(stop, dtype=jnp.bfloat16),
+        [jax.ShapeDtypeStruct((), jnp.float32)],
+        opset=27,
+    )
+
+    onnx.checker.check_model(model)
+    range_nodes = [node for node in model.graph.node if node.op_type == "Range"]
+    assert len(range_nodes) == 1
+    assert model.graph.output[0].name == range_nodes[0].output[0]
+    assert model.graph.output[0].type.tensor_type.elem_type == TensorProto.BFLOAT16
+
+
+def test_resize_area_static_exact_matrix_path() -> None:
+    model = to_onnx(
+        lambda x: jimage.resize(x, (2, 2), method="area", antialias=False),
+        [jax.ShapeDtypeStruct((4, 4), np.float32)],
+        opset=23,
+    )
+
+    onnx.checker.check_model(model)
+    assert _node_types(model) == ["Reshape", "MatMul", "Reshape"]
+    assert tuple(
+        dim.dim_value for dim in model.graph.output[0].type.tensor_type.shape.dim
+    ) == (2, 2)
+
+
+def test_resize_cubic_pytorch_static_exact_matrix_path() -> None:
+    model = to_onnx(
+        lambda x: jimage.resize(x, (3, 5), method="cubic-pytorch", antialias=False),
+        [jax.ShapeDtypeStruct((2, 2), np.float32)],
+        opset=23,
+    )
+
+    onnx.checker.check_model(model)
+    assert _node_types(model) == ["Reshape", "MatMul", "Reshape"]
+    assert tuple(
+        dim.dim_value for dim in model.graph.output[0].type.tensor_type.shape.dim
+    ) == (3, 5)

--- a/tests/t_generator.py
+++ b/tests/t_generator.py
@@ -45,6 +45,8 @@ _FALLBACK_NP_TYPE_TO_TENSOR_TYPE = {
     np.dtype(np.complex64): TensorProto.COMPLEX64,
     np.dtype(np.complex128): TensorProto.COMPLEX128,
 }
+if hasattr(TensorProto, "BFLOAT16"):
+    _FALLBACK_NP_TYPE_TO_TENSOR_TYPE[np.dtype(jnp.bfloat16)] = TensorProto.BFLOAT16
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

- add Opset 27 native FP16/BF16 Range lowering for lax.iota and jnp.arange while preserving older-opset cast fallbacks
- add exact static matrix lowering for JAX 0.10 resize methods area and cubic-pytorch
- add JAX 0.10.2 batching compatibility for removed batching.not_mapped
- make the MaxText random-normal zero patch tolerant of removed JAX private random helpers
- document the updated stack under upcoming jax2onnx 0.14.1

## Validation

- poetry run pytest -q
- poetry run ruff check .
- ./scripts/check_typing.sh
- poetry run mkdocs build --strict
- git diff --check
- GitHub Actions CI #27749889109: green across onnxruntime-web smoke and Python 3.11, 3.12, 3.13, 3.14

## Notes

ORT 1.27 still cannot execute ai.onnx opset 27 models in the generated numeric path, so the new Opset 27 iota metadata keeps structural and dtype coverage while skipping numeric runtime validation.