### PR TITLE
[codex] Add JAX upgrade compatibility follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,50 +53,6 @@ jobs:
     - name: Run onnxruntime-web smoke checks
       run: scripts/run_onnxruntime_web_smoke.sh
 
-  onnxruntime-web-full:
-    name: onnxruntime-web full
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '22'
-        cache: npm
-
-    - name: Install Poetry
-      run: pip install "poetry>=2.0,<3.0"
-
-    - name: Install Python dependencies
-      run: |
-        poetry install --no-interaction
-        poetry run pip install pytest-xdist
-
-    - name: Install Node dependencies
-      run: npm ci
-
-    - name: Generate tests
-      run: poetry run python scripts/generate_tests.py
-
-    - name: Run full onnxruntime-web checks
-      env:
-        JAX_PLATFORMS: cpu
-        JAX_ENABLE_X64: "True"
-      run: |
-        scripts/run_onnxruntime_web_full.sh \
-          -n auto \
-          --dist=loadscope \
-          --durations=50 \
-          --durations-min=1
-
   minimum-dependencies:
     name: minimum dependency versions
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,58 @@ jobs:
     - name: Run onnxruntime-web smoke checks
       run: scripts/run_onnxruntime_web_smoke.sh
 
+  minimum-dependencies:
+    name: minimum dependency versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install Poetry
+      run: pip install "poetry>=2.0,<3.0"
+
+    - name: Install dependencies
+      run: |
+        poetry install --no-interaction
+        poetry run python scripts/install_minimum_dependencies.py
+        poetry run pip check
+
+    - name: Report dependency versions
+      run: |
+        poetry run python - <<'PY'
+        import flax
+        import jax
+        import onnx
+        import onnx_ir
+        import onnxruntime
+
+        print(f"jax=={jax.__version__}")
+        print(f"flax=={flax.__version__}")
+        print(f"onnx=={onnx.__version__}")
+        print(f"onnx-ir=={onnx_ir.__version__}")
+        print(f"onnxruntime=={onnxruntime.__version__}")
+        PY
+
+    - name: Generate tests
+      run: poetry run python scripts/generate_tests.py
+
+    - name: Run minimum-version compatibility checks
+      env:
+        JAX_PLATFORMS: cpu
+        JAX_ENABLE_X64: "True"
+      run: |
+        poetry run pytest -q \
+          tests/extra_tests/framework/test_jax_compat.py \
+          tests/extra_tests/framework/test_minimum_dependency_installer.py \
+          tests/primitives/test_linen.py \
+          tests/extra_tests/test_bfloat16_capability_matrix.py
+
   test: 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,50 @@ jobs:
     - name: Run onnxruntime-web smoke checks
       run: scripts/run_onnxruntime_web_smoke.sh
 
+  onnxruntime-web-full:
+    name: onnxruntime-web full
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: npm
+
+    - name: Install Poetry
+      run: pip install "poetry>=2.0,<3.0"
+
+    - name: Install Python dependencies
+      run: |
+        poetry install --no-interaction
+        poetry run pip install pytest-xdist
+
+    - name: Install Node dependencies
+      run: npm ci
+
+    - name: Generate tests
+      run: poetry run python scripts/generate_tests.py
+
+    - name: Run full onnxruntime-web checks
+      env:
+        JAX_PLATFORMS: cpu
+        JAX_ENABLE_X64: "True"
+      run: |
+        scripts/run_onnxruntime_web_full.sh \
+          -n auto \
+          --dist=loadscope \
+          --durations=50 \
+          --durations-min=1
+
   minimum-dependencies:
     name: minimum dependency versions
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ This page is the quick briefing for automated agents (or humans) dropping into t
 
 - **Pipeline:** Everything runs through the IR-only converter. `converter/` builds `onnx_ir` graphs; `plugins/` land primitive-specific lowering; `tests/` cover both policy and regression cases.
 - **Docs map:** Start with `docs/developer_guide/architecture.md` for the architecture overview. Technical playbooks live under `docs/developer_guide/advanced_topics/` (builder etiquette, expect_graph usage, control-flow wiring, IR optimizer, reflection guardrails, etc.). Release history lives under `docs/about/`; coverage pages and examples live under `docs/user_guide/`.
-- **Tooling:** Python 3.11+, Poetry, Ruff, Black, mypy, pytest. Supported runtime stack is **JAX ≥0.7.2** and **Flax/NNX ≥0.12.0**.
+- **Tooling:** Python 3.11+, Poetry, Ruff, Black, mypy, pytest. Supported runtime stack is **JAX ≥0.8.1** and **Flax/NNX ≥0.12.1**.
 - **Recent heads-up (2025-10-02):**
-  - NNX examples construct RNGs via `with_rng_seed(...)`; avoid inline lambdas so callables stay hashable under JAX 0.7.
+  - NNX examples construct RNGs via `with_rng_seed(...)`; avoid inline lambdas so callables stay hashable under current JAX releases.
   - Attention plugins normalise masked weights to avoid float32 NaNs; tests rely on that behaviour.
 
 ---
@@ -38,7 +38,7 @@ Keep these handy—most deep-dives live there instead of here.
   - `poetry run pytest -q`
   - `poetry run mkdocs build --strict` for doc changes
 - Debug flags exist for the IR optimizer (`JAX2ONNX_*_DEBUG`); see the optimizer dev guide for the full matrix.
-- JAX 0.7.x specifics:
+- JAX 0.8+ specifics:
   - No `jax_dynamic_shapes` auto-toggle.
   - Primitive parameters must be hashable; `construct_and_call(...).with_dtype(...)` constructs modules once per dtype.
   - Flax NNX requires attributes that hold arrays to be wrapped in `nnx.List` / `nnx.data`.

--- a/docs/about/dependencies.md
+++ b/docs/about/dependencies.md
@@ -12,4 +12,7 @@
 | [`onnxruntime`](https://github.com/microsoft/onnxruntime) | 1.27.0 |
 | [`onnxruntime-web`](https://www.npmjs.com/package/onnxruntime-web) | 1.26.0 |
 
+`onnxruntime-web` remains on the latest stable npm release; move it to a
+matching `1.27.x` version once that line is published as a stable Web package.
+
 *For minimum supported versions and optional extras, see [`pyproject.toml`](https://github.com/enpasos/jax2onnx/blob/main/pyproject.toml). For the fully resolved Poetry environment, see `poetry.lock`.*

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -24,7 +24,8 @@
   exact.
 * **Refresh the validation stack:** Update the upcoming documented runtime
   stack to JAX `0.10.2`, Equinox `0.13.8`, ONNX `1.22.0`, ONNX Runtime
-  `1.27.0`, and the matching `onnxruntime-web` versions for Web validation.
+  `1.27.0`, and keep Web validation on the latest stable
+  `onnxruntime-web` release until a matching `1.27.x` Web package is published.
 
 ## Current Version
 

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -22,6 +22,14 @@
   native FP16/BF16 `Range` for `opset=27` exports and keeping older exports on
   the cast fallback; cover new JAX 0.10 resize methods where the ONNX mapping is
   exact.
+* **Centralize JAX internal API compatibility:** Add a package-level JAX
+  compatibility layer and migrate direct `jax.core` / `jax.extend.core` usage
+  across converter and plugin code so JAX internal API moves are handled in one
+  place.
+* **Validate declared lower bounds in CI:** Raise the installable minimum JAX
+  version to `0.8.1` for Flax/NNX `0.12.1` compatibility, add a
+  minimum-dependency workflow job, and cover the lower-bound installer with
+  focused tests.
 * **Refresh the validation stack:** Update the upcoming documented runtime
   stack to JAX `0.10.2`, Equinox `0.13.8`, ONNX `1.22.0`, ONNX Runtime
   `1.27.0`, and keep Web validation on the latest stable

--- a/jax2onnx/_compat/__init__.py
+++ b/jax2onnx/_compat/__init__.py
@@ -1,0 +1,3 @@
+# jax2onnx/_compat/__init__.py
+
+"""Package-wide compatibility shims for unstable upstream APIs."""

--- a/jax2onnx/_compat/jax.py
+++ b/jax2onnx/_compat/jax.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, cast
 
 from jax import core as jax_core
 
@@ -49,6 +49,38 @@ def ensure_batching_not_mapped_attr() -> Any:
 NOT_MAPPED: Any = ensure_batching_not_mapped_attr()
 
 
+def _resolve_definitely_equal_shape() -> Callable[[Any, Any], bool]:
+    try:  # Prefer the internal helper when available (moved in newer JAX versions).
+        from jax._src import core as jax_core_src
+
+        return cast(Callable[[Any, Any], bool], jax_core_src.definitely_equal_shape)
+    except Exception:  # pragma: no cover - fallback for older/older-stub JAX
+        try:
+            return cast(
+                Callable[[Any, Any], bool],
+                getattr(jax_core, "definitely_equal_shape"),
+            )
+        except Exception:  # pragma: no cover - minimal fallback
+
+            def fallback(s1: Any, s2: Any) -> bool:
+                if len(s1) != len(s2):
+                    return False
+                for d1, d2 in zip(s1, s2):
+                    if d1 is d2:
+                        continue
+                    try:
+                        if d1 != d2:
+                            return False
+                    except Exception:
+                        return False
+                return True
+
+            return fallback
+
+
+definitely_equal_shape: Callable[[Any, Any], bool] = _resolve_definitely_equal_shape()
+
+
 __all__ = [
     "AbstractValue",
     "ClosedJaxpr",
@@ -64,6 +96,7 @@ __all__ = [
     "Var",
     "ad",
     "batching",
+    "definitely_equal_shape",
     "dim_constant",
     "ensure_batching_not_mapped_attr",
     "jax_core",

--- a/jax2onnx/_compat/jax.py
+++ b/jax2onnx/_compat/jax.py
@@ -1,4 +1,4 @@
-# jax2onnx/plugins/jax/_jax_compat.py
+# jax2onnx/_compat/jax.py
 
 """Compatibility helpers for JAX APIs that are moving across releases."""
 

--- a/jax2onnx/plugins/dm_pix/depth_to_space.py
+++ b/jax2onnx/plugins/dm_pix/depth_to_space.py
@@ -20,7 +20,7 @@ from jax2onnx.plugins._ir_shapes import (
 )
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/dm_pix/depth_to_space.py
+++ b/jax2onnx/plugins/dm_pix/depth_to_space.py
@@ -10,9 +10,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core
-from jax.extend.core import Primitive
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -23,6 +20,13 @@ from jax2onnx.plugins._ir_shapes import (
 )
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
@@ -125,19 +129,19 @@ class DmPixDepthToSpacePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         block_size: int,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         bs = _check_block_size(block_size)
         spec = jax.ShapeDtypeStruct(getattr(x, "shape", ()), getattr(x, "dtype", None))
         result = jax.eval_shape(
             lambda arr: _depth_to_space_impl(arr, block_size=bs),
             spec,
         )
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = dict(getattr(eqn, "params", {}))
         block_size_param = params.get("block_size")
         if block_size_param is None:

--- a/jax2onnx/plugins/dm_pix/space_to_depth.py
+++ b/jax2onnx/plugins/dm_pix/space_to_depth.py
@@ -20,7 +20,7 @@ from jax2onnx.plugins._ir_shapes import (
 )
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/dm_pix/space_to_depth.py
+++ b/jax2onnx/plugins/dm_pix/space_to_depth.py
@@ -10,9 +10,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core
-from jax.extend.core import Primitive
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -23,6 +20,13 @@ from jax2onnx.plugins._ir_shapes import (
 )
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
@@ -135,19 +139,19 @@ class DmPixSpaceToDepthPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         block_size: int,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         bs = _check_block_size(block_size)
         spec = jax.ShapeDtypeStruct(getattr(x, "shape", ()), getattr(x, "dtype", None))
         result = jax.eval_shape(
             lambda arr: _space_to_depth_impl(arr, block_size=bs),
             spec,
         )
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = dict(getattr(eqn, "params", {}))
         block_size_param = params.get("block_size")
         if block_size_param is None:

--- a/jax2onnx/plugins/flax/linen/activation.py
+++ b/jax2onnx/plugins/flax/linen/activation.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, Final, cast
 
-import jax
 import jax.nn as jnn
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import JaxprEqn, Primitive
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
@@ -156,7 +155,7 @@ class LinenActivationPlugin(PrimitiveLeafPlugin):
     _PRIM.multiple_results = False
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "Linen activation patching should not reach lowering; it is inlined."
         )

--- a/jax2onnx/plugins/flax/linen/avg_pool.py
+++ b/jax2onnx/plugins/flax/linen/avg_pool.py
@@ -7,9 +7,9 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from flax import linen as nn
-from jax.extend.core import Primitive
 import onnx_ir as ir
 
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
@@ -161,7 +161,7 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
         strides: Optional[Sequence[int]],
         padding: str,
         count_include_pad: bool,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         actual_strides = (
             tuple(strides) if strides is not None else (1,) * len(window_shape)
         )
@@ -170,7 +170,7 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
         if orig_call is None:
             rank = x.ndim
             if rank < 3:
-                return jax.core.ShapedArray(x.shape, x.dtype)
+                return ShapedArray(x.shape, x.dtype)
             H, W, C = x.shape[-3], x.shape[-2], x.shape[-1]
             kH, kW = window_shape
             sH, sW = actual_strides
@@ -187,7 +187,7 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
             oH = _dim_out(H, kH, sH, padding)
             oW = _dim_out(W, kW, sW, padding)
             out_shape = (*x.shape[:-3], oH, oW, C)
-            return jax.core.ShapedArray(out_shape, x.dtype)
+            return ShapedArray(out_shape, x.dtype)
 
         x_spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
 
@@ -201,10 +201,10 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
             )
 
         out = jax.eval_shape(_helper, x_spec)
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
     # ---------------- lowering (IR) ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         y_var = eqn.outvars[0]
         window_shape = tuple(int(v) for v in eqn.params["window_shape"])

--- a/jax2onnx/plugins/flax/linen/batch_norm.py
+++ b/jax2onnx/plugins/flax/linen/batch_norm.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, ClassVar, Final
 import logging
 import numpy as np
 from flax import linen as nn
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.nnx import batch_norm as nnx_batch_norm
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx

--- a/jax2onnx/plugins/flax/linen/conv.py
+++ b/jax2onnx/plugins/flax/linen/conv.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, ClassVar, Final, Sequence
 import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen import linear as linen_linear
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.nnx import conv as nnx_conv
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx

--- a/jax2onnx/plugins/flax/linen/conv_local.py
+++ b/jax2onnx/plugins/flax/linen/conv_local.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Sequence
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import linen as nn
 from flax.linen import linear as linen_linear
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (

--- a/jax2onnx/plugins/flax/linen/conv_transpose.py
+++ b/jax2onnx/plugins/flax/linen/conv_transpose.py
@@ -6,11 +6,11 @@ from typing import Any, Callable, ClassVar, Sequence, cast
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import linen as nn
 from flax.linen import linear as linen_linear
 import onnx_ir as ir
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._utils import cast_param_like
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
@@ -201,7 +201,7 @@ class ConvTransposePlugin(PrimitiveLeafPlugin):
         transpose_kernel: bool,
         precision: Any = None,
         preferred_element_type: Any = None,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         x_spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         k_spec = jax.ShapeDtypeStruct(kernel.shape, kernel.dtype)
         b_spec = jax.ShapeDtypeStruct(bias.shape, bias.dtype)
@@ -222,7 +222,7 @@ class ConvTransposePlugin(PrimitiveLeafPlugin):
             return y
 
         out = jax.eval_shape(_shape_fn, x_spec, k_spec, b_spec)
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
     def lower(self, ctx: Any, eqn: Any) -> None:
         builder = getattr(ctx, "builder", None)

--- a/jax2onnx/plugins/flax/linen/dense.py
+++ b/jax2onnx/plugins/flax/linen/dense.py
@@ -5,10 +5,10 @@ from typing import Any, Callable, ClassVar, Final
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import linen as nn
 import onnx_ir as ir
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     register_primitive,
@@ -251,11 +251,11 @@ class DensePlugin(PrimitiveLeafPlugin):
         *,
         use_bias: bool,
         dimension_numbers: Any = None,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del bias, use_bias, dimension_numbers
         _, k1 = kernel.shape
         out_shape = (*x.shape[:-1], k1)
-        return jax.core.ShapedArray(out_shape, x.dtype)
+        return ShapedArray(out_shape, x.dtype)
 
     def lower(self, ctx: Any, eqn: Any) -> None:
         builder = getattr(ctx, "builder", None)

--- a/jax2onnx/plugins/flax/linen/dense_general.py
+++ b/jax2onnx/plugins/flax/linen/dense_general.py
@@ -6,10 +6,10 @@ from typing import Any, Callable, ClassVar, Final, Sequence
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import linen as nn
 from flax.linen import linear as linen_linear
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.nnx import linear_general as nnx_linear_general
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
@@ -160,7 +160,7 @@ class DenseGeneralPlugin(nnx_linear_general.LinearGeneralPlugin):
     @staticmethod
     def abstract_eval(
         x: Any, kernel: Any, bias: Any, *, dimension_numbers: Any
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del bias
         ((lhs_contract, rhs_contract), (lhs_batch, rhs_batch)) = dimension_numbers
         lhs_contract = tuple(lhs_contract)
@@ -179,7 +179,7 @@ class DenseGeneralPlugin(nnx_linear_general.LinearGeneralPlugin):
         out_shape = tuple(x.shape[i] for i in lhs_batch)
         out_shape += tuple(x.shape[i] for i in lhs_other)
         out_shape += tuple(kernel.shape[i] for i in rhs_other)
-        return jax.core.ShapedArray(out_shape, x.dtype)
+        return ShapedArray(out_shape, x.dtype)
 
     @staticmethod
     def _make_patch(orig_fn: Callable[..., Any] | None) -> Callable[..., Any]:

--- a/jax2onnx/plugins/flax/linen/dot_product_attention.py
+++ b/jax2onnx/plugins/flax/linen/dot_product_attention.py
@@ -7,10 +7,9 @@ from typing import Any, Callable, ClassVar
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,

--- a/jax2onnx/plugins/flax/linen/dropout.py
+++ b/jax2onnx/plugins/flax/linen/dropout.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar
 
 from flax import linen as nn
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.nnx import dropout as nnx_dropout
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx

--- a/jax2onnx/plugins/flax/linen/einsum.py
+++ b/jax2onnx/plugins/flax/linen/einsum.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 import jax
 import jax.numpy as jnp
-from jax import core
-from jax.extend.core import Primitive
 from flax import linen as nn
 from flax.linen import module as linen_module
 import onnx_ir as ir
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -125,7 +124,7 @@ class EinsumPlugin(PrimitiveLeafPlugin):
         broadcasted_bias_shape: tuple[int, ...] | None = None,
         precision: Any | None = None,
         preferred_element_type: Any | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         bias = maybe_bias[0] if maybe_bias else None
 
         def _shape_fn(x_arg: Any, kernel_arg: Any, bias_arg: Any | None = None) -> Any:
@@ -157,7 +156,7 @@ class EinsumPlugin(PrimitiveLeafPlugin):
             else:
                 raise TypeError("Unexpected output from linen.Einsum abstract eval")
 
-        return core.ShapedArray(out_spec.shape, out_spec.dtype)
+        return ShapedArray(out_spec.shape, out_spec.dtype)
 
     def lower(self, ctx: Any, eqn: Any) -> None:
         params: dict[str, Any] = dict(getattr(eqn, "params", {}) or {})

--- a/jax2onnx/plugins/flax/linen/embed.py
+++ b/jax2onnx/plugins/flax/linen/embed.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, Final
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.nnx import embed as nnx_embed
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx

--- a/jax2onnx/plugins/flax/linen/group_norm.py
+++ b/jax2onnx/plugins/flax/linen/group_norm.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, ClassVar, Final, Sequence
 
 import jax.numpy as jnp
 from flax import linen as nn
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins.flax.nnx import group_norm as nnx_group_norm
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (

--- a/jax2onnx/plugins/flax/linen/instance_norm.py
+++ b/jax2onnx/plugins/flax/linen/instance_norm.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, Final, Sequence, cast
 
-import jax
 import jax.numpy as jnp
 import onnx_ir as ir
 from flax import linen as nn
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import JaxprEqn, Primitive
 from jax2onnx.plugins._ir_shapes import (
     _dim_label_from_value_or_aval,
     _ensure_value_metadata,
@@ -126,7 +125,7 @@ class InstanceNormPlugin(nnx_group_norm.GroupNormPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
     _ORIGINAL_CALL: ClassVar[Callable[..., Any] | None] = None
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, scale_var, bias_var = eqn.invars[:3]
         y_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/flax/linen/layer_norm.py
+++ b/jax2onnx/plugins/flax/linen/layer_norm.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, List, Optional, Sequence, Tuple, cast
 
-import jax
 import jax.numpy as jnp
 from flax import linen as nn
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 import onnx_ir as ir
 
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
@@ -250,7 +248,7 @@ class LayerNormPlugin(PrimitiveLeafPlugin):
         x_aval = x if isinstance(x, ShapedArray) else ShapedArray(x.shape, x.dtype)
         return ShapedArray(x_aval.shape, x_aval.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_v = ctx.get_value_for_var(eqn.invars[0])
         scale_v = ctx.get_value_for_var(eqn.invars[1])
         bias_v = ctx.get_value_for_var(eqn.invars[2])

--- a/jax2onnx/plugins/flax/linen/max_pool.py
+++ b/jax2onnx/plugins/flax/linen/max_pool.py
@@ -7,9 +7,9 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from flax import linen as nn
-from jax.extend.core import Primitive
 
 import onnx_ir as ir
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
@@ -138,22 +138,22 @@ class MaxPoolPlugin(PrimitiveLeafPlugin):
         window_shape: Sequence[int],
         strides: Optional[Sequence[int]],
         padding: str,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         strides = MaxPoolPlugin._normalize_stride(strides, window_shape)
         padding = str(padding)
         shape = list(x.shape)
         if len(shape) <= 2:
-            return jax.core.ShapedArray(tuple(shape), x.dtype)
+            return ShapedArray(tuple(shape), x.dtype)
         spatial = shape[1:-1]
         out_spatial = [
             MaxPoolPlugin._compute_output_dim(dim, w, s, padding)
             for dim, w, s in zip(spatial, window_shape, strides, strict=False)
         ]
         out_shape = (shape[0], *out_spatial, shape[-1])
-        return jax.core.ShapedArray(tuple(out_shape), x.dtype)
+        return ShapedArray(tuple(out_shape), x.dtype)
 
     # ---------------- lowering ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars[:1]
         (y_var,) = eqn.outvars[:1]
 

--- a/jax2onnx/plugins/flax/linen/min_pool.py
+++ b/jax2onnx/plugins/flax/linen/min_pool.py
@@ -7,9 +7,9 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from flax.linen import pooling as linen_pooling
-from jax.extend.core import Primitive
 
 import onnx_ir as ir
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
@@ -110,22 +110,22 @@ class MinPoolPlugin(PrimitiveLeafPlugin):
         window_shape: Sequence[int],
         strides: Optional[Sequence[int]],
         padding: str,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         strides = MinPoolPlugin._normalize_stride(strides, window_shape)
         padding = str(padding)
         shape = list(x.shape)
         if len(shape) <= 2:
-            return jax.core.ShapedArray(tuple(shape), x.dtype)
+            return ShapedArray(tuple(shape), x.dtype)
         spatial = shape[1:-1]
         out_spatial = [
             MinPoolPlugin._compute_output_dim(dim, w, s, padding)
             for dim, w, s in zip(spatial, window_shape, strides, strict=False)
         ]
         out_shape = (shape[0], *out_spatial, shape[-1])
-        return jax.core.ShapedArray(tuple(out_shape), x.dtype)
+        return ShapedArray(tuple(out_shape), x.dtype)
 
     # ---------------- lowering ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars[:1]
         (y_var,) = eqn.outvars[:1]
 

--- a/jax2onnx/plugins/flax/linen/multi_head_attention.py
+++ b/jax2onnx/plugins/flax/linen/multi_head_attention.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar
 
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.linen.multi_head_dot_product_attention import _make_mha_patch
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx

--- a/jax2onnx/plugins/flax/linen/multi_head_dot_product_attention.py
+++ b/jax2onnx/plugins/flax/linen/multi_head_dot_product_attention.py
@@ -6,10 +6,9 @@ from typing import Any, Callable, ClassVar
 
 import jax
 import jax.numpy as jnp
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (

--- a/jax2onnx/plugins/flax/linen/pool.py
+++ b/jax2onnx/plugins/flax/linen/pool.py
@@ -8,9 +8,9 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from flax.linen import pooling as linen_pooling
-from jax.extend.core import Primitive
 import onnx_ir as ir
 
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
@@ -204,7 +204,7 @@ class PoolPlugin(PrimitiveLeafPlugin):
         window_shape: Sequence[int],
         strides: Optional[Sequence[int]],
         padding: object,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         strides = PoolPlugin._normalize_stride(strides, window_shape)
         if not isinstance(padding, str):
             raise NotImplementedError(
@@ -212,17 +212,17 @@ class PoolPlugin(PrimitiveLeafPlugin):
             )
         shape = list(x.shape)
         if len(shape) <= 2:
-            return jax.core.ShapedArray(tuple(shape), x.dtype)
+            return ShapedArray(tuple(shape), x.dtype)
         spatial = shape[1:-1]
         out_spatial = [
             PoolPlugin._compute_output_dim(dim, w, s, padding)
             for dim, w, s in zip(spatial, window_shape, strides, strict=False)
         ]
         out_shape = (shape[0], *out_spatial, shape[-1])
-        return jax.core.ShapedArray(tuple(out_shape), x.dtype)
+        return ShapedArray(tuple(out_shape), x.dtype)
 
     # ---------------- lowering ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars[:1]
         (y_var,) = eqn.outvars[:1]
 

--- a/jax2onnx/plugins/flax/linen/prelu.py
+++ b/jax2onnx/plugins/flax/linen/prelu.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, ClassVar
 
 import jax.numpy as jnp
 from flax import linen as nn
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins.flax.nnx import prelu as nnx_prelu
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec

--- a/jax2onnx/plugins/flax/linen/recurrent.py
+++ b/jax2onnx/plugins/flax/linen/recurrent.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-import jax
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.flax.test_utils import (
     linen_bidirectional_to_nnx,
@@ -75,7 +73,7 @@ class SimpleCellPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "SimpleCell primitive should not reach lowering; it is inlined."
         )
@@ -120,7 +118,7 @@ class GRUCellPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "GRUCell primitive should not reach lowering; it is inlined."
         )
@@ -166,7 +164,7 @@ class MGUCellPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "MGUCell primitive should not reach lowering; it is inlined."
         )
@@ -211,7 +209,7 @@ class LSTMCellPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "LSTMCell primitive should not reach lowering; it is inlined."
         )
@@ -256,7 +254,7 @@ class OptimizedLSTMCellPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "OptimizedLSTMCell primitive should not reach lowering; it is inlined."
         )
@@ -309,7 +307,7 @@ class ConvLSTMCellPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "ConvLSTMCell primitive should not reach lowering; it is inlined."
         )
@@ -359,7 +357,7 @@ class RNNPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "RNN primitive should not reach lowering; it is inlined."
         )
@@ -413,7 +411,7 @@ class BidirectionalPlugin(PrimitiveLeafPlugin):
         del args, kwargs
         return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         raise NotImplementedError(
             "Bidirectional primitive should not reach lowering; it is inlined."
         )

--- a/jax2onnx/plugins/flax/linen/rms_norm.py
+++ b/jax2onnx/plugins/flax/linen/rms_norm.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, ClassVar, Final, Sequence
 
 import jax.numpy as jnp
 from flax import linen as nn
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins.flax.nnx import rms_norm as nnx_rms_norm
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (

--- a/jax2onnx/plugins/flax/linen/self_attention.py
+++ b/jax2onnx/plugins/flax/linen/self_attention.py
@@ -6,10 +6,9 @@ from typing import Any, Callable, ClassVar
 
 import jax
 import jax.numpy as jnp
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 from flax import linen as nn
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (

--- a/jax2onnx/plugins/flax/linen/spectral_norm.py
+++ b/jax2onnx/plugins/flax/linen/spectral_norm.py
@@ -8,9 +8,8 @@ import jax
 import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen import linear as linen_linear
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,

--- a/jax2onnx/plugins/flax/linen/weight_norm.py
+++ b/jax2onnx/plugins/flax/linen/weight_norm.py
@@ -8,9 +8,8 @@ import jax
 import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen import linear as linen_linear
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins.flax.test_utils import linen_to_nnx
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,

--- a/jax2onnx/plugins/flax/nnx/avg_pool.py
+++ b/jax2onnx/plugins/flax/nnx/avg_pool.py
@@ -5,11 +5,11 @@ from typing import Any, Callable, ClassVar, Final, Optional, Sequence, cast
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import nnx
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -219,7 +219,7 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
         strides: Optional[Sequence[int]],
         padding: str,
         count_include_pad: bool,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         # Prefer original nnx.avg_pool if we captured it, else shape math.
         actual_strides = (
             tuple(strides) if strides is not None else (1,) * len(window_shape)
@@ -232,7 +232,7 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
 
             rank = x.ndim
             if rank < 3:
-                return jax.core.ShapedArray(x.shape, x.dtype)
+                return ShapedArray(x.shape, x.dtype)
             H, W, C = x.shape[-3], x.shape[-2], x.shape[-1]
             kH, kW = window_shape
             sH, sW = actual_strides
@@ -250,7 +250,7 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
             oH = _dim_out(H, kH, sH, padding)
             oW = _dim_out(W, kW, sW, padding)
             out_shape = (*x.shape[:-3], oH, oW, C)
-            return jax.core.ShapedArray(out_shape, x.dtype)
+            return ShapedArray(out_shape, x.dtype)
 
         x_spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
 
@@ -264,10 +264,10 @@ class AvgPoolPlugin(PrimitiveLeafPlugin):
             )
 
         out = jax.eval_shape(_helper, x_spec)
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
     # ---------------- lowering (IR) ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         y_var = eqn.outvars[0]
         window_shape = tuple(int(v) for v in eqn.params["window_shape"])

--- a/jax2onnx/plugins/flax/nnx/avg_pool.py
+++ b/jax2onnx/plugins/flax/nnx/avg_pool.py
@@ -9,7 +9,7 @@ from flax import nnx
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG

--- a/jax2onnx/plugins/flax/nnx/batch_norm.py
+++ b/jax2onnx/plugins/flax/nnx/batch_norm.py
@@ -13,7 +13,7 @@ from jax2onnx.converter.typing_support import (
     LoweringContextProtocol,
 )
 from jax2onnx.ir_utils import numpy_dtype_to_ir
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,

--- a/jax2onnx/plugins/flax/nnx/batch_norm.py
+++ b/jax2onnx/plugins/flax/nnx/batch_norm.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 import logging
 import numpy as np
-import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import nnx
 import onnx_ir as ir
 
@@ -15,6 +13,7 @@ from jax2onnx.converter.typing_support import (
     LoweringContextProtocol,
 )
 from jax2onnx.ir_utils import numpy_dtype_to_ir
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,
@@ -285,12 +284,12 @@ class BatchNormPlugin(PrimitiveLeafPlugin):
         epsilon: float,
         momentum: float,
         **_ignored: Any,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del scale, bias, mean, var, epsilon, momentum
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------------- lowering (IR) ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         builder = _require_builder(ctx)
         x_var, scale_var, bias_var, mean_var, var_var = eqn.invars[:5]
         y_var = eqn.outvars[0]

--- a/jax2onnx/plugins/flax/nnx/conv.py
+++ b/jax2onnx/plugins/flax/nnx/conv.py
@@ -18,7 +18,6 @@ import math
 import jax
 import jax.numpy as jnp
 from jax import lax
-from jax.extend.core import Primitive
 from flax import nnx
 from flax.nnx.nn import linear as nnx_linear
 import onnx_ir as ir
@@ -27,6 +26,7 @@ from jax2onnx.converter.typing_support import (
     IRBuilderProtocol,
     LoweringContextProtocol,
 )
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
@@ -1552,7 +1552,7 @@ class ConvPlugin(PrimitiveLeafPlugin):
         dilations: Sequence[int] | int = 1,
         dimension_numbers: Any | None = None,
         feature_group_count: int = 1,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         # Compute shapes using ONLY lax.* — never call (patched) nnx.Conv.__call__ here.
         # Calling the original would re-enter prim.bind and recurse.
         x_shape = tuple(x.shape)
@@ -1631,10 +1631,10 @@ class ConvPlugin(PrimitiveLeafPlugin):
         # Unflatten leading dims back to (N, *extra, ...).
         out_spatial = y_flat.shape[1 : 1 + conv_spatial]
         y_shape = (*leading, *out_spatial, k_shape[-1])
-        return jax.core.ShapedArray(y_shape, y_flat.dtype)
+        return ShapedArray(y_shape, y_flat.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> ir.Value:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> ir.Value:
         x_var, k_var, b_var = eqn.invars[:3]
         y_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/flax/nnx/dot_product_attention.py
+++ b/jax2onnx/plugins/flax/nnx/dot_product_attention.py
@@ -6,11 +6,10 @@ from typing import Any, Callable, ClassVar, Final, Tuple, Union, cast
 
 import numpy as np
 from flax import nnx
-from jax import core
-from jax.extend.core import Primitive
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx._compat.jax import AbstractValue, JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins._ir_shapes import (
     _ensure_value_metadata,
     _stamp_type_and_shape,
@@ -258,16 +257,16 @@ class DotProductAttentionPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        q: core.AbstractValue,
-        k: core.AbstractValue,
-        v: core.AbstractValue,
+        q: AbstractValue,
+        k: AbstractValue,
+        v: AbstractValue,
         *_: Any,
         **__: Any,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del k, v
-        return core.ShapedArray(q.shape, q.dtype)
+        return ShapedArray(q.shape, q.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params_raw = dict(getattr(eqn, "params", {}) or {})
         params = {
             key: (val.value if isinstance(val, _DynamicParamWrapper) else val)

--- a/jax2onnx/plugins/flax/nnx/dropout.py
+++ b/jax2onnx/plugins/flax/nnx/dropout.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Optional, cast
 import numpy as np
-import jax
-from jax.extend.core import Primitive
 import logging
+from jax2onnx._compat.jax import AbstractValue, JaxprEqn, Primitive, ShapedArray
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
@@ -286,16 +285,16 @@ class DropoutPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         deterministic: Any,
         *,
         rate: float,
         call_time: bool = False,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del deterministic, rate, call_time
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         # JAXPR carries two invars: x, deterministic ; rate is a static param.
         invars = list(eqn.invars)
         x_var = invars[0]

--- a/jax2onnx/plugins/flax/nnx/einsum.py
+++ b/jax2onnx/plugins/flax/nnx/einsum.py
@@ -9,10 +9,9 @@ import jax
 import jax.numpy as jnp
 import onnx_ir as ir
 from flax import nnx
-from jax import core
-from jax.extend.core import Primitive
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx._compat.jax import AbstractValue, JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins._ir_shapes import (
     _ensure_value_metadata,
     _stamp_type_and_shape,
@@ -123,9 +122,9 @@ class EinsumModulePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        kernel: core.AbstractValue,
-        *maybe_bias: core.AbstractValue,
+        x: AbstractValue,
+        kernel: AbstractValue,
+        *maybe_bias: AbstractValue,
         einsum_str: str,
         use_bias_bool: bool,
         precision: Any | None = None,
@@ -133,7 +132,7 @@ class EinsumModulePlugin(PrimitiveLeafPlugin):
         preferred_element_type: Any | None = None,
         dtype: Any | None = None,
         param_dtype: Any | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del dtype, param_dtype
         bias = maybe_bias[0] if maybe_bias else None
 
@@ -169,9 +168,9 @@ class EinsumModulePlugin(PrimitiveLeafPlugin):
             else:
                 raise TypeError("Unexpected output from nnx.Einsum abstract eval")
 
-        return core.ShapedArray(out_spec.shape, out_spec.dtype)
+        return ShapedArray(out_spec.shape, out_spec.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = dict(getattr(eqn, "params", {}) or {})
         equation = str(params["einsum_str"])
         use_bias = bool(params.get("use_bias_bool", False))

--- a/jax2onnx/plugins/flax/nnx/elu.py
+++ b/jax2onnx/plugins/flax/nnx/elu.py
@@ -5,7 +5,12 @@ from typing import Any, Callable, ClassVar, cast
 
 import numpy as np
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -100,14 +105,12 @@ class EluPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, alpha: float = 1.0
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, alpha: float = 1.0) -> ShapedArray:
         del alpha
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         alpha = float(eqn.params.get("alpha", 1.0))
         attrs: dict[str, float] = {}
         if not np.isclose(alpha, 1.0):

--- a/jax2onnx/plugins/flax/nnx/elu.py
+++ b/jax2onnx/plugins/flax/nnx/elu.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, ClassVar, cast
 
 import numpy as np
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/embed.py
+++ b/jax2onnx/plugins/flax/nnx/embed.py
@@ -6,11 +6,10 @@ from typing import Any, Callable, ClassVar, Final, cast
 
 import jax.numpy as jnp
 from flax import nnx
-from jax import core
-from jax.extend.core import Primitive
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx._compat.jax import AbstractValue, JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins._ir_shapes import (
     _dim_label_from_value_or_aval,
     _ensure_value_metadata,
@@ -94,13 +93,11 @@ class EmbedPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        indices: core.AbstractValue, embedding: core.AbstractValue
-    ) -> core.ShapedArray:
+    def abstract_eval(indices: AbstractValue, embedding: AbstractValue) -> ShapedArray:
         features = embedding.shape[-1]
-        return core.ShapedArray(indices.shape + (features,), embedding.dtype)
+        return ShapedArray(indices.shape + (features,), embedding.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         indices_var, embedding_var = eqn.invars[:2]
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/flax/nnx/gelu.py
+++ b/jax2onnx/plugins/flax/nnx/gelu.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Optional, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/gelu.py
+++ b/jax2onnx/plugins/flax/nnx/gelu.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Optional, cast
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -95,14 +100,12 @@ class GeluPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, *, approximate: bool = True
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, *, approximate: bool = True) -> ShapedArray:
         del approximate
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         approximate = bool(eqn.params.get("approximate", True))
         approx_str = "tanh" if approximate else "none"
         lower_unary_elementwise(

--- a/jax2onnx/plugins/flax/nnx/group_norm.py
+++ b/jax2onnx/plugins/flax/nnx/group_norm.py
@@ -12,7 +12,7 @@ from jax2onnx.converter.typing_support import (
     IRBuilderProtocol,
     LoweringContextProtocol,
 )
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,

--- a/jax2onnx/plugins/flax/nnx/group_norm.py
+++ b/jax2onnx/plugins/flax/nnx/group_norm.py
@@ -6,13 +6,13 @@ from typing import Any, Callable, ClassVar, Final, Sequence, cast
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from jax.extend.core import Primitive
 
 import onnx_ir as ir
 from jax2onnx.converter.typing_support import (
     IRBuilderProtocol,
     LoweringContextProtocol,
 )
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,
@@ -233,12 +233,12 @@ class GroupNormPlugin(PrimitiveLeafPlugin):
         epsilon: float,
         num_groups: int,
         channel_axis: int,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del scale, bias, epsilon, num_groups, channel_axis
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------------- lowering ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, scale_var, bias_var = eqn.invars[:3]
         y_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/flax/nnx/layer_norm.py
+++ b/jax2onnx/plugins/flax/nnx/layer_norm.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, List, Optional, Sequence, cast
 import jax.numpy as jnp
 from flax import nnx
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
 
 import onnx_ir as ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx.plugins.jax._jax_compat import Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,

--- a/jax2onnx/plugins/flax/nnx/layer_norm.py
+++ b/jax2onnx/plugins/flax/nnx/layer_norm.py
@@ -8,7 +8,7 @@ from flax import nnx
 
 import onnx_ir as ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
-from jax2onnx.plugins.jax._jax_compat import Primitive, ShapedArray
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,

--- a/jax2onnx/plugins/flax/nnx/leaky_relu.py
+++ b/jax2onnx/plugins/flax/nnx/leaky_relu.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Optional, cast
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -106,14 +111,12 @@ class LeakyReluPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, negative_slope: float = 0.01
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, negative_slope: float = 0.01) -> ShapedArray:
         del negative_slope
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         negative_slope = float(eqn.params.get("negative_slope", 0.01))
         lower_unary_elementwise(
             ctx,

--- a/jax2onnx/plugins/flax/nnx/leaky_relu.py
+++ b/jax2onnx/plugins/flax/nnx/leaky_relu.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Optional, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/linear.py
+++ b/jax2onnx/plugins/flax/nnx/linear.py
@@ -5,11 +5,11 @@ from typing import Any, Callable, ClassVar, Final, Optional
 import numpy as np
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
 from flax import nnx
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,
@@ -286,7 +286,7 @@ class LinearPlugin(PrimitiveLeafPlugin):
         *,
         use_bias: bool,
         dimension_numbers: Any = None,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         # If we don't have the original __call__, fall back to shape math.
         orig_call = LinearPlugin._ORIGINAL_LINEAR_CALL
         if orig_call is None:
@@ -296,7 +296,7 @@ class LinearPlugin(PrimitiveLeafPlugin):
             k0, k1 = kernel.shape
             need_flat = (k0 != x.shape[-1]) or (x.ndim > 2)
             out_shape = (x.shape[0], k1) if need_flat else (*x.shape[:-1], k1)
-            return jax.core.ShapedArray(out_shape, x.dtype)
+            return ShapedArray(out_shape, x.dtype)
 
         if dimension_numbers is None:
             lhs, rhs = ((x.ndim - 1,), (0,))
@@ -345,7 +345,7 @@ class LinearPlugin(PrimitiveLeafPlugin):
 
         out = jax.eval_shape(_helper, x_spec, k_spec, b_spec)
         out = jax.tree_util.tree_leaves(out)[0]
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
     # ---------- lowering (IR) ----------
 

--- a/jax2onnx/plugins/flax/nnx/linear_general.py
+++ b/jax2onnx/plugins/flax/nnx/linear_general.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 import numpy as np
 import jax
-from jax.extend.core import Primitive
 from flax import nnx
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx._compat.jax import Primitive, ShapedArray
 from jax2onnx.plugins._utils import cast_param_like, inline_reshape_initializer
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
@@ -416,7 +416,7 @@ class LinearGeneralPlugin(PrimitiveLeafPlugin):
     @staticmethod
     def abstract_eval(
         x: Any, kernel: Any, bias: Any, *, dimension_numbers: Any
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         orig_call = LinearGeneralPlugin._ORIGINAL_CALL
         if orig_call is None:
             # Pure shape math fallback.
@@ -426,7 +426,7 @@ class LinearGeneralPlugin(PrimitiveLeafPlugin):
             out_shape = tuple(x.shape[i] for i in x_batch) + tuple(
                 kernel.shape[i] for i in k_out
             )
-            return jax.core.ShapedArray(out_shape, x.dtype)
+            return ShapedArray(out_shape, x.dtype)
 
         x_spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         k_spec = jax.ShapeDtypeStruct(kernel.shape, kernel.dtype)
@@ -483,7 +483,7 @@ class LinearGeneralPlugin(PrimitiveLeafPlugin):
 
         out = jax.eval_shape(_helper, x_spec, k_spec, b_spec)
         out = jax.tree_util.tree_leaves(out)[0]
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
     # ---------- lowering (IR) ----------
     def lower(self, ctx: LoweringContextProtocol, eqn: Any) -> None:

--- a/jax2onnx/plugins/flax/nnx/log_softmax.py
+++ b/jax2onnx/plugins/flax/nnx/log_softmax.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, cast
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -84,14 +89,12 @@ class LogSoftmaxPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, axis: int = -1
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, axis: int = -1) -> ShapedArray:
         del axis
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         axis = int(eqn.params.get("axis", -1))
 

--- a/jax2onnx/plugins/flax/nnx/log_softmax.py
+++ b/jax2onnx/plugins/flax/nnx/log_softmax.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/max_pool.py
+++ b/jax2onnx/plugins/flax/nnx/max_pool.py
@@ -10,7 +10,7 @@ from flax import nnx
 
 import onnx_ir as ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._ir_shapes import (

--- a/jax2onnx/plugins/flax/nnx/max_pool.py
+++ b/jax2onnx/plugins/flax/nnx/max_pool.py
@@ -7,10 +7,10 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from jax.extend.core import Primitive
 
 import onnx_ir as ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._ir_shapes import (
@@ -167,22 +167,22 @@ class MaxPoolPlugin(PrimitiveLeafPlugin):
         window_shape: Sequence[int],
         strides: Optional[Sequence[int]],
         padding: str,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         strides = MaxPoolPlugin._normalize_stride(strides, window_shape)
         padding = str(padding)
         shape = list(x.shape)
         if len(shape) <= 2:
-            return jax.core.ShapedArray(tuple(shape), x.dtype)
+            return ShapedArray(tuple(shape), x.dtype)
         spatial = shape[1:-1]
         out_spatial = [
             MaxPoolPlugin._compute_output_dim(dim, w, s, padding)
             for dim, w, s in zip(spatial, window_shape, strides, strict=False)
         ]
         out_shape = (shape[0], *out_spatial, shape[-1])
-        return jax.core.ShapedArray(tuple(out_shape), x.dtype)
+        return ShapedArray(tuple(out_shape), x.dtype)
 
     # ---------------- lowering ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars[:1]
         (y_var,) = eqn.outvars[:1]
 

--- a/jax2onnx/plugins/flax/nnx/prelu.py
+++ b/jax2onnx/plugins/flax/nnx/prelu.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, ClassVar, Final
 
 import jax.numpy as jnp
 from flax import nnx
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/prelu.py
+++ b/jax2onnx/plugins/flax/nnx/prelu.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final
 
-import jax
-from jax.interpreters import batching
 import jax.numpy as jnp
 from flax import nnx
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
@@ -76,13 +80,13 @@ class PReluPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
-        negative_slope: jax.core.AbstractValue,
-    ) -> jax.core.ShapedArray:
+        x: AbstractValue,
+        negative_slope: AbstractValue,
+    ) -> ShapedArray:
         del negative_slope
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, slope_var = eqn.invars
         y_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/flax/nnx/relu.py
+++ b/jax2onnx/plugins/flax/nnx/relu.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 from typing import Any, Final, cast
 
-import jax
-from jax.extend.core import Primitive as JaxPrimitive
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    Primitive as JaxPrimitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -32,9 +35,9 @@ def _init_relu_prim() -> JaxPrimitive:
 nnx_relu_p: Final[JaxPrimitive] = _init_relu_prim()
 
 
-def _relu_abstract_eval(x_aval: jax.core.ShapedArray) -> jax.core.ShapedArray:
+def _relu_abstract_eval(x_aval: ShapedArray) -> ShapedArray:
     # ReLU preserves shape & dtype
-    return jax.core.ShapedArray(x_aval.shape, x_aval.dtype)
+    return ShapedArray(x_aval.shape, x_aval.dtype)
 
 
 # Idempotent abstract eval registration
@@ -81,7 +84,7 @@ class ReluPlugin(PrimitiveLeafPlugin):
     """
 
     # ---------------- lowering (IR) ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/flax/nnx/relu.py
+++ b/jax2onnx/plugins/flax/nnx/relu.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Any, Final, cast
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     Primitive as JaxPrimitive,
     ShapedArray,

--- a/jax2onnx/plugins/flax/nnx/rms_norm.py
+++ b/jax2onnx/plugins/flax/nnx/rms_norm.py
@@ -7,7 +7,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from flax import nnx
-from jax.extend.core import Primitive
 
 import onnx_ir as ir
 from jax2onnx.converter.typing_support import (
@@ -15,6 +14,7 @@ from jax2onnx.converter.typing_support import (
     LoweringContextProtocol,
 )
 from jax2onnx.ir_utils import numpy_dtype_to_ir
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,
@@ -187,14 +187,12 @@ class RMSNormPlugin(PrimitiveLeafPlugin):
 
     # ---------------- abstract eval ----------------
     @staticmethod
-    def abstract_eval(
-        x: Any, scale: Any, *, epsilon: float, axis: int
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: Any, scale: Any, *, epsilon: float, axis: int) -> ShapedArray:
         del scale, epsilon, axis
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------------- lowering ----------------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, scale_var = eqn.invars[:2]
         y_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/flax/nnx/rms_norm.py
+++ b/jax2onnx/plugins/flax/nnx/rms_norm.py
@@ -14,7 +14,7 @@ from jax2onnx.converter.typing_support import (
     LoweringContextProtocol,
 )
 from jax2onnx.ir_utils import numpy_dtype_to_ir
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive, ShapedArray
+from jax2onnx._compat.jax import JaxprEqn, Primitive, ShapedArray
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     construct_and_call,

--- a/jax2onnx/plugins/flax/nnx/sigmoid.py
+++ b/jax2onnx/plugins/flax/nnx/sigmoid.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, cast
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -51,11 +56,11 @@ class SigmoidPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/flax/nnx/sigmoid.py
+++ b/jax2onnx/plugins/flax/nnx/sigmoid.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/softmax.py
+++ b/jax2onnx/plugins/flax/nnx/softmax.py
@@ -5,7 +5,7 @@ from typing import Callable, ClassVar, cast
 
 import jax
 import jax.numpy as jnp  # noqa: F401  (kept for parity with other plugins)
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/softmax.py
+++ b/jax2onnx/plugins/flax/nnx/softmax.py
@@ -5,7 +5,12 @@ from typing import Callable, ClassVar, cast
 
 import jax
 import jax.numpy as jnp  # noqa: F401  (kept for parity with other plugins)
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -54,15 +59,13 @@ class SoftmaxPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, axis: int = -1
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, axis: int = -1) -> ShapedArray:
         del axis
         # Output has same shape/dtype as input
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
 
         axis = int(eqn.params.get("axis", -1))

--- a/jax2onnx/plugins/flax/nnx/softplus.py
+++ b/jax2onnx/plugins/flax/nnx/softplus.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Callable, ClassVar, cast
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/softplus.py
+++ b/jax2onnx/plugins/flax/nnx/softplus.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 from typing import Callable, ClassVar, cast
-import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -53,11 +57,11 @@ class SoftplusPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/flax/nnx/tanh.py
+++ b/jax2onnx/plugins/flax/nnx/tanh.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Callable, ClassVar, cast
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/flax/nnx/tanh.py
+++ b/jax2onnx/plugins/flax/nnx/tanh.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 from typing import Callable, ClassVar, cast
-import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from flax import nnx
 from numpy.typing import ArrayLike
 
@@ -49,11 +53,11 @@ class TanhPlugin(PrimitiveLeafPlugin):
 
     # ---------- abstract eval ----------
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
     # ---------- lowering (IR) ----------
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/_autodiff_utils.py
+++ b/jax2onnx/plugins/jax/_autodiff_utils.py
@@ -8,9 +8,8 @@ import os
 from typing import Any, Callable, Iterable, cast
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import ad, batching
 
+from jax2onnx.plugins.jax._jax_compat import Primitive, ad, batching
 
 logger: logging.Logger = logging.getLogger("jax2onnx.plugins.autodiff")
 

--- a/jax2onnx/plugins/jax/_autodiff_utils.py
+++ b/jax2onnx/plugins/jax/_autodiff_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, cast
 
 import jax
 
-from jax2onnx.plugins.jax._jax_compat import Primitive, ad, batching
+from jax2onnx._compat.jax import Primitive, ad, batching
 
 logger: logging.Logger = logging.getLogger("jax2onnx.plugins.autodiff")
 

--- a/jax2onnx/plugins/jax/_batching_compat.py
+++ b/jax2onnx/plugins/jax/_batching_compat.py
@@ -1,22 +1,13 @@
 # jax2onnx/plugins/jax/_batching_compat.py
 
-"""Compatibility helpers for JAX batching internals."""
+"""Backward-compatible imports for JAX batching internals."""
 
 from __future__ import annotations
 
-from typing import Any
+from jax2onnx.plugins.jax._jax_compat import (
+    NOT_MAPPED,
+    batching,
+    ensure_batching_not_mapped_attr,
+)
 
-from jax.interpreters import batching
-
-
-def ensure_batching_not_mapped_attr() -> Any:
-    """Expose the legacy ``batching.not_mapped`` name when JAX uses ``None``."""
-
-    try:
-        return batching.not_mapped
-    except AttributeError:
-        setattr(batching, "not_mapped", None)
-        return None
-
-
-NOT_MAPPED: Any = ensure_batching_not_mapped_attr()
+__all__ = ["NOT_MAPPED", "batching", "ensure_batching_not_mapped_attr"]

--- a/jax2onnx/plugins/jax/_batching_compat.py
+++ b/jax2onnx/plugins/jax/_batching_compat.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     NOT_MAPPED,
     batching,
     ensure_batching_not_mapped_attr,

--- a/jax2onnx/plugins/jax/_batching_utils.py
+++ b/jax2onnx/plugins/jax/_batching_utils.py
@@ -6,9 +6,12 @@ from typing import Any, Sequence, Callable, cast
 
 import numpy as np
 from jax import lax
-from jax.interpreters import batching
 
-from jax2onnx.plugins.jax._batching_compat import ensure_batching_not_mapped_attr
+from jax2onnx.plugins.jax._jax_compat import (
+    NOT_MAPPED,
+    batching,
+    ensure_batching_not_mapped_attr,
+)
 
 ensure_batching_not_mapped_attr()
 
@@ -48,7 +51,7 @@ _definitely_equal_shape: Callable[[Any, Any], bool] = _resolve_definitely_equal_
 
 
 def _handle_scalar_broadcasting(ndim: int, x: Any, dim: Any) -> Any:
-    if dim is batching.not_mapped or ndim == np.ndim(x):
+    if dim is NOT_MAPPED or ndim == np.ndim(x):
         return x
     return lax.expand_dims(x, tuple(range(np.ndim(x), ndim)))
 
@@ -60,9 +63,7 @@ def broadcast_batcher_compat(
     if len(args) <= 1:
         raise ValueError("broadcast_batcher_compat requires at least two arguments")
 
-    shape, dim = next(
-        (x.shape, d) for x, d in zip(args, dims) if d is not batching.not_mapped
-    )
+    shape, dim = next((x.shape, d) for x, d in zip(args, dims) if d is not NOT_MAPPED)
     if all(
         _definitely_equal_shape(shape, x.shape) and d == dim
         for x, d in zip(args, dims)

--- a/jax2onnx/plugins/jax/_batching_utils.py
+++ b/jax2onnx/plugins/jax/_batching_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Sequence, Callable, cast
 import numpy as np
 from jax import lax
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     NOT_MAPPED,
     batching,
     ensure_batching_not_mapped_attr,

--- a/jax2onnx/plugins/jax/_batching_utils.py
+++ b/jax2onnx/plugins/jax/_batching_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Callable, cast
+from typing import Any, Sequence
 
 import numpy as np
 from jax import lax
@@ -10,44 +10,11 @@ from jax import lax
 from jax2onnx._compat.jax import (
     NOT_MAPPED,
     batching,
+    definitely_equal_shape,
     ensure_batching_not_mapped_attr,
 )
 
 ensure_batching_not_mapped_attr()
-
-
-def _resolve_definitely_equal_shape() -> Callable[[Any, Any], bool]:
-    try:  # Prefer the internal helper when available (moved in newer JAX versions).
-        from jax._src import core as _core_src
-
-        return cast(Callable[[Any, Any], bool], _core_src.definitely_equal_shape)
-    except Exception:  # pragma: no cover - fallback for older/older-stub JAX
-        try:
-            from jax import core as _core_public
-
-            return cast(
-                Callable[[Any, Any], bool],
-                getattr(_core_public, "definitely_equal_shape"),
-            )
-        except Exception:  # pragma: no cover - minimal fallback
-
-            def _fallback(s1: Any, s2: Any) -> bool:
-                if len(s1) != len(s2):
-                    return False
-                for d1, d2 in zip(s1, s2):
-                    if d1 is d2:
-                        continue
-                    try:
-                        if d1 != d2:
-                            return False
-                    except Exception:
-                        return False
-                return True
-
-            return _fallback
-
-
-_definitely_equal_shape: Callable[[Any, Any], bool] = _resolve_definitely_equal_shape()
 
 
 def _handle_scalar_broadcasting(ndim: int, x: Any, dim: Any) -> Any:
@@ -65,7 +32,7 @@ def broadcast_batcher_compat(
 
     shape, dim = next((x.shape, d) for x, d in zip(args, dims) if d is not NOT_MAPPED)
     if all(
-        _definitely_equal_shape(shape, x.shape) and d == dim
+        definitely_equal_shape(shape, x.shape) and d == dim
         for x, d in zip(args, dims)
         if np.ndim(x)
     ):

--- a/jax2onnx/plugins/jax/_jax_compat.py
+++ b/jax2onnx/plugins/jax/_jax_compat.py
@@ -1,0 +1,52 @@
+# jax2onnx/plugins/jax/_jax_compat.py
+
+"""Compatibility helpers for JAX APIs that are moving across releases."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jax import core as jax_core
+
+try:  # JAX 0.10+ exposes this through jax.errors.
+    from jax.errors import InconclusiveDimensionOperation
+except ImportError:  # pragma: no cover - compatibility with older JAX versions
+    from jax.core import InconclusiveDimensionOperation
+from jax.extend import core as jax_core_ext
+from jax.extend.core import ClosedJaxpr, JaxprEqn, Primitive
+from jax.interpreters import ad, batching
+
+
+AbstractValue = jax_core.AbstractValue
+ShapedArray = jax_core.ShapedArray
+Var = jax_core_ext.Var
+
+
+def ensure_batching_not_mapped_attr() -> Any:
+    """Expose the legacy ``batching.not_mapped`` name when JAX uses ``None``."""
+
+    try:
+        return batching.not_mapped
+    except AttributeError:
+        setattr(batching, "not_mapped", None)
+        return None
+
+
+NOT_MAPPED: Any = ensure_batching_not_mapped_attr()
+
+
+__all__ = [
+    "AbstractValue",
+    "ClosedJaxpr",
+    "InconclusiveDimensionOperation",
+    "JaxprEqn",
+    "NOT_MAPPED",
+    "Primitive",
+    "ShapedArray",
+    "Var",
+    "ad",
+    "batching",
+    "ensure_batching_not_mapped_attr",
+    "jax_core",
+    "jax_core_ext",
+]

--- a/jax2onnx/plugins/jax/_jax_compat.py
+++ b/jax2onnx/plugins/jax/_jax_compat.py
@@ -21,6 +21,10 @@ AbstractValue = jax_core.AbstractValue
 ShapedArray = jax_core.ShapedArray
 Tracer = jax_core.Tracer
 Var = jax_core_ext.Var
+try:
+    DropVar = jax_core_ext.DropVar
+except AttributeError:  # pragma: no cover - compatibility with older JAX versions
+    DropVar = jax_core.DropVar
 
 
 def dim_constant(value: int) -> Any:
@@ -48,6 +52,7 @@ NOT_MAPPED: Any = ensure_batching_not_mapped_attr()
 __all__ = [
     "AbstractValue",
     "ClosedJaxpr",
+    "DropVar",
     "InconclusiveDimensionOperation",
     "Jaxpr",
     "JaxprEqn",

--- a/jax2onnx/plugins/jax/_jax_compat.py
+++ b/jax2onnx/plugins/jax/_jax_compat.py
@@ -13,13 +13,23 @@ try:  # JAX 0.10+ exposes this through jax.errors.
 except ImportError:  # pragma: no cover - compatibility with older JAX versions
     from jax.core import InconclusiveDimensionOperation
 from jax.extend import core as jax_core_ext
-from jax.extend.core import ClosedJaxpr, JaxprEqn, Primitive
+from jax.extend.core import ClosedJaxpr, JaxprEqn, Literal, Primitive
 from jax.interpreters import ad, batching
 
 
 AbstractValue = jax_core.AbstractValue
 ShapedArray = jax_core.ShapedArray
+Tracer = jax_core.Tracer
 Var = jax_core_ext.Var
+
+
+def dim_constant(value: int) -> Any:
+    """Return a symbolic dimension constant when the active JAX exposes one."""
+
+    dim_constant_fn = getattr(jax_core, "dim_constant", None)
+    if callable(dim_constant_fn):
+        return dim_constant_fn(value)
+    return value
 
 
 def ensure_batching_not_mapped_attr() -> Any:
@@ -40,12 +50,15 @@ __all__ = [
     "ClosedJaxpr",
     "InconclusiveDimensionOperation",
     "JaxprEqn",
+    "Literal",
     "NOT_MAPPED",
     "Primitive",
     "ShapedArray",
+    "Tracer",
     "Var",
     "ad",
     "batching",
+    "dim_constant",
     "ensure_batching_not_mapped_attr",
     "jax_core",
     "jax_core_ext",

--- a/jax2onnx/plugins/jax/_jax_compat.py
+++ b/jax2onnx/plugins/jax/_jax_compat.py
@@ -13,7 +13,7 @@ try:  # JAX 0.10+ exposes this through jax.errors.
 except ImportError:  # pragma: no cover - compatibility with older JAX versions
     from jax.core import InconclusiveDimensionOperation
 from jax.extend import core as jax_core_ext
-from jax.extend.core import ClosedJaxpr, JaxprEqn, Literal, Primitive
+from jax.extend.core import ClosedJaxpr, Jaxpr, JaxprEqn, Literal, Primitive
 from jax.interpreters import ad, batching
 
 
@@ -49,6 +49,7 @@ __all__ = [
     "AbstractValue",
     "ClosedJaxpr",
     "InconclusiveDimensionOperation",
+    "Jaxpr",
     "JaxprEqn",
     "Literal",
     "NOT_MAPPED",

--- a/jax2onnx/plugins/jax/core/custom_jvp_call.py
+++ b/jax2onnx/plugins/jax/core/custom_jvp_call.py
@@ -9,7 +9,7 @@ import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive
+from jax2onnx._compat.jax import JaxprEqn, Primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import lower_jaxpr_eqns
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,

--- a/jax2onnx/plugins/jax/core/custom_jvp_call.py
+++ b/jax2onnx/plugins/jax/core/custom_jvp_call.py
@@ -4,24 +4,17 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from jax import core
 import numpy as np
+import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import lower_jaxpr_eqns
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     register_primitive,
 )
-
-
-import jax
-
-try:  # JAX 0.4+ lives in jax.extend.core
-    from jax.extend.core import Primitive as JaxPrimitive
-except ImportError:  # pragma: no cover - fallback for older JAX
-    from jax.core import Primitive as JaxPrimitive
 
 
 @jax.custom_jvp
@@ -57,9 +50,9 @@ def _square_jvp(primals: tuple[Any, ...], tangents: tuple[Any, ...]) -> tuple[An
 class CustomJvpCallPlugin(PrimitiveLeafPlugin):
     """Inline the body of a ``custom_jvp_call`` primitive into the current IR."""
 
-    _PRIM: ClassVar[JaxPrimitive | None] = None
+    _PRIM: ClassVar[Primitive | None] = None
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         closed = eqn.params.get("call_jaxpr")
         if closed is None:
             raise ValueError("custom_jvp_call missing call_jaxpr parameter")

--- a/jax2onnx/plugins/jax/core/custom_vjp_call.py
+++ b/jax2onnx/plugins/jax/core/custom_vjp_call.py
@@ -9,7 +9,7 @@ import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive
+from jax2onnx._compat.jax import JaxprEqn, Primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import lower_jaxpr_eqns
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,

--- a/jax2onnx/plugins/jax/core/custom_vjp_call.py
+++ b/jax2onnx/plugins/jax/core/custom_vjp_call.py
@@ -4,23 +4,17 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from jax import core
 import numpy as np
+import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn, Primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import lower_jaxpr_eqns
 from jax2onnx.plugins.plugin_system import (
     PrimitiveLeafPlugin,
     register_primitive,
 )
-
-import jax
-
-try:  # JAX 0.4+ lives in jax.extend.core
-    from jax.extend.core import Primitive as JaxPrimitive
-except ImportError:  # pragma: no cover - fallback for older JAX
-    from jax.core import Primitive as JaxPrimitive
 
 
 @jax.custom_vjp
@@ -62,9 +56,9 @@ _square.defvjp(_square_fwd, _square_bwd)
 class CustomVjpCallPlugin(PrimitiveLeafPlugin):
     """Inline the body of a ``custom_vjp_call`` primitive into the current IR."""
 
-    _PRIM: ClassVar[JaxPrimitive | None] = None
+    _PRIM: ClassVar[Primitive | None] = None
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         closed = eqn.params.get("call_jaxpr")
         if closed is None:
             raise ValueError("custom_vjp_call missing call_jaxpr parameter")

--- a/jax2onnx/plugins/jax/core/dim_as_value.py
+++ b/jax2onnx/plugins/jax/core/dim_as_value.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, cast
 
-from jax import core
 import numpy as np
 import onnx_ir as ir
 
@@ -13,8 +12,9 @@ from jax2onnx.converter.typing_support import (
     LoweringContextProtocol,
     SymbolicDimOrigin,
 )
-from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _stamp_type_and_shape
+from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.utils.shape_poly import dim_expr_constant_value, is_dim_expr
@@ -97,7 +97,7 @@ def _infer_rank(value: ir.Value, axis: int) -> int:
     ],
 )
 class DimAsValuePlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         out_var = eqn.outvars[0]
         out_spec = ctx.get_value_for_var(
             out_var, name_hint=ctx.fresh_name("dim_as_value_out")

--- a/jax2onnx/plugins/jax/core/dim_as_value.py
+++ b/jax2onnx/plugins/jax/core/dim_as_value.py
@@ -14,7 +14,7 @@ from jax2onnx.converter.typing_support import (
 )
 from jax2onnx.plugins._ir_shapes import _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.utils.shape_poly import dim_expr_constant_value, is_dim_expr

--- a/jax2onnx/plugins/jax/core/name.py
+++ b/jax2onnx/plugins/jax/core/name.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import cast
 
-from jax import core
 import onnx_ir as ir
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -13,6 +12,7 @@ from jax2onnx.plugins._ir_shapes import (
     _ensure_value_metadata,
     _stamp_type_and_shape,
 )
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -33,7 +33,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class NamePlugin(PrimitiveLeafPlugin):
     """Lower the ad_checkpoint name primitive to an ONNX Identity node."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         inp_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/core/name.py
+++ b/jax2onnx/plugins/jax/core/name.py
@@ -12,7 +12,7 @@ from jax2onnx.plugins._ir_shapes import (
     _ensure_value_metadata,
     _stamp_type_and_shape,
 )
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/image/_common.py
+++ b/jax2onnx/plugins/jax/image/_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, cast
 
-from jax2onnx.plugins.jax._jax_compat import Primitive
+from jax2onnx._compat.jax import Primitive
 
 
 BoundCallable = Callable[..., Any]

--- a/jax2onnx/plugins/jax/image/_common.py
+++ b/jax2onnx/plugins/jax/image/_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, cast
 
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import Primitive
 
 
 BoundCallable = Callable[..., Any]

--- a/jax2onnx/plugins/jax/image/resize.py
+++ b/jax2onnx/plugins/jax/image/resize.py
@@ -9,13 +9,13 @@ import jax
 import jax.image as jimage
 import numpy as np
 import onnx_ir as ir
-from jax import core
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
+from jax2onnx.plugins.jax._jax_compat import AbstractValue, JaxprEqn, ShapedArray
 from jax2onnx.plugins.jax.image._common import get_orig_impl, make_image_primitive
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
@@ -355,12 +355,12 @@ class ImageResizePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        image: core.AbstractValue,
+        image: AbstractValue,
         *,
         shape: Sequence[int | np.integer],
         method: str | jimage.ResizeMethod = "linear",
         **params: object,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if shape is None:
             raise TypeError("resize requires a target shape")
         try:
@@ -370,9 +370,9 @@ class ImageResizePlugin(PrimitiveLeafPlugin):
         dtype = getattr(image, "dtype", None)
         if dtype is None:
             raise TypeError("resize abstract value is missing dtype")
-        return core.ShapedArray(out_shape, dtype)
+        return ShapedArray(out_shape, dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         image_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/image/resize.py
+++ b/jax2onnx/plugins/jax/image/resize.py
@@ -15,7 +15,7 @@ from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
-from jax2onnx.plugins.jax._jax_compat import AbstractValue, JaxprEqn, ShapedArray
+from jax2onnx._compat.jax import AbstractValue, JaxprEqn, ShapedArray
 from jax2onnx.plugins.jax.image._common import get_orig_impl, make_image_primitive
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive

--- a/jax2onnx/plugins/jax/lax/_arg_utils.py
+++ b/jax2onnx/plugins/jax/lax/_arg_utils.py
@@ -9,8 +9,6 @@ from typing import Any, Sequence
 import numpy as np
 import onnx_ir as ir
 
-from jax import core
-
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import numpy_dtype_to_ir
 from jax2onnx.plugins._ir_shapes import (
@@ -18,12 +16,13 @@ from jax2onnx.plugins._ir_shapes import (
     _stamp_type_and_shape,
     _to_ir_dim_for_shape,
 )
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.jax.lax._control_flow_utils import builder_cast, builder_identity
 
 
 def lower_arg_reduction(
     ctx: LoweringContextProtocol,
-    eqn: core.JaxprEqn,
+    eqn: JaxprEqn,
     *,
     op_name: str,
     name_prefix: str,

--- a/jax2onnx/plugins/jax/lax/_arg_utils.py
+++ b/jax2onnx/plugins/jax/lax/_arg_utils.py
@@ -16,7 +16,7 @@ from jax2onnx.plugins._ir_shapes import (
     _stamp_type_and_shape,
     _to_ir_dim_for_shape,
 )
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.jax.lax._control_flow_utils import builder_cast, builder_identity
 
 

--- a/jax2onnx/plugins/jax/lax/_control_flow_utils.py
+++ b/jax2onnx/plugins/jax/lax/_control_flow_utils.py
@@ -14,7 +14,7 @@ from jax2onnx.converter.lowering_dispatch import (
 )
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
-from jax2onnx.plugins.jax._jax_compat import Jaxpr
+from jax2onnx._compat.jax import Jaxpr
 from jax2onnx.plugins.plugin_system import PLUGIN_REGISTRY
 
 

--- a/jax2onnx/plugins/jax/lax/_control_flow_utils.py
+++ b/jax2onnx/plugins/jax/lax/_control_flow_utils.py
@@ -9,13 +9,12 @@ from typing import Any, cast
 import onnx_ir as ir
 from onnx_ir import Shape as IRShape
 
-from jax import core
-
 from jax2onnx.converter.lowering_dispatch import (
     lower_jaxpr_with_plugins,
 )
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
+from jax2onnx.plugins.jax._jax_compat import Jaxpr
 from jax2onnx.plugins.plugin_system import PLUGIN_REGISTRY
 
 
@@ -99,7 +98,7 @@ def builder_loop(
 
 def lower_jaxpr_eqns(
     ctx: LoweringContextProtocol,
-    jaxpr: core.Jaxpr,
+    jaxpr: Jaxpr,
     *,
     source: str = "control_flow",
 ) -> None:

--- a/jax2onnx/plugins/jax/lax/_reduce_utils.py
+++ b/jax2onnx/plugins/jax/lax/_reduce_utils.py
@@ -9,11 +9,10 @@ from typing import Any, Final, Iterable, Optional, Sequence, cast
 import numpy as np
 import onnx_ir as ir
 
-from jax import core
-
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64, _scalar_i64
 
 
@@ -69,7 +68,7 @@ def _maybe_cast_input(
 
 def lower_reduction(
     ctx: LoweringContextProtocol,
-    eqn: core.JaxprEqn,
+    eqn: JaxprEqn,
     *,
     op_type: str,
     allow_dtype_param: bool = True,
@@ -244,7 +243,7 @@ def lower_reduction(
 
 
 def lower_boolean_reduction(
-    ctx: LoweringContextProtocol, eqn: core.JaxprEqn, *, mode: str
+    ctx: LoweringContextProtocol, eqn: JaxprEqn, *, mode: str
 ) -> None:
     operand_var = eqn.invars[0]
     out_var = eqn.outvars[0]

--- a/jax2onnx/plugins/jax/lax/_reduce_utils.py
+++ b/jax2onnx/plugins/jax/lax/_reduce_utils.py
@@ -12,7 +12,7 @@ import onnx_ir as ir
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64, _scalar_i64
 
 

--- a/jax2onnx/plugins/jax/lax/abs.py
+++ b/jax2onnx/plugins/jax/lax/abs.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/abs.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/abs.py
+++ b/jax2onnx/plugins/jax/lax/abs.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/abs.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AbsPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/acos.py
+++ b/jax2onnx/plugins/jax/lax/acos.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/acos.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AcosPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/acos.py
+++ b/jax2onnx/plugins/jax/lax/acos.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/acos.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/acosh.py
+++ b/jax2onnx/plugins/jax/lax/acosh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/acosh.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/acosh.py
+++ b/jax2onnx/plugins/jax/lax/acosh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/acosh.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AcoshPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/add_any.py
+++ b/jax2onnx/plugins/jax/lax/add_any.py
@@ -17,7 +17,7 @@ from jax2onnx.plugins._loop_extent_meta import (
     set_axis0_override,
 )
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.jax.lax.add import AddPlugin, lower_add
 from jax2onnx.plugins.plugin_system import register_primitive
 

--- a/jax2onnx/plugins/jax/lax/add_any.py
+++ b/jax2onnx/plugins/jax/lax/add_any.py
@@ -17,6 +17,7 @@ from jax2onnx.plugins._loop_extent_meta import (
     set_axis0_override,
 )
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.jax.lax.add import AddPlugin, lower_add
 from jax2onnx.plugins.plugin_system import register_primitive
 
@@ -48,7 +49,7 @@ from jax2onnx.plugins.plugin_system import register_primitive
 class AddAnyPlugin(AddPlugin):
     """Alias for JAX's internal ``add_any`` primitive."""
 
-    def lower(self, ctx: Any, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: Any, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/and.py
+++ b/jax2onnx/plugins/jax/lax/and.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -56,7 +56,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AndPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/and.py
+++ b/jax2onnx/plugins/jax/lax/and.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/asin.py
+++ b/jax2onnx/plugins/jax/lax/asin.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/asin.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AsinPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/asin.py
+++ b/jax2onnx/plugins/jax/lax/asin.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/asin.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/asinh.py
+++ b/jax2onnx/plugins/jax/lax/asinh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/asinh.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AsinhPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/asinh.py
+++ b/jax2onnx/plugins/jax/lax/asinh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/asinh.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/atan.py
+++ b/jax2onnx/plugins/jax/lax/atan.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/atan.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AtanPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/atan.py
+++ b/jax2onnx/plugins/jax/lax/atan.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/atan.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/atanh.py
+++ b/jax2onnx/plugins/jax/lax/atanh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/atanh.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class AtanhPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/atanh.py
+++ b/jax2onnx/plugins/jax/lax/atanh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/atanh.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/bitwise_not.py
+++ b/jax2onnx/plugins/jax/lax/bitwise_not.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import AbstractValue, JaxprEqn
 import jax
 import numpy as np
 
@@ -53,10 +53,10 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 )
 class BitwiseNotPlugin(PrimitiveLeafPlugin):
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.AbstractValue:
+    def abstract_eval(x: AbstractValue) -> AbstractValue:
         return x
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/bitwise_not.py
+++ b/jax2onnx/plugins/jax/lax/bitwise_not.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import AbstractValue, JaxprEqn
+from jax2onnx._compat.jax import AbstractValue, JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/cbrt.py
+++ b/jax2onnx/plugins/jax/lax/cbrt.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy

--- a/jax2onnx/plugins/jax/lax/cbrt.py
+++ b/jax2onnx/plugins/jax/lax/cbrt.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
@@ -38,7 +38,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class CbrtPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.cbrt`` to ``sign(x) * pow(abs(x), 1/3)`` in ONNX."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/ceil.py
+++ b/jax2onnx/plugins/jax/lax/ceil.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/ceil.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/ceil.py
+++ b/jax2onnx/plugins/jax/lax/ceil.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/ceil.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -34,7 +34,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class CeilPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/clz.py
+++ b/jax2onnx/plugins/jax/lax/clz.py
@@ -7,7 +7,7 @@ from typing import Any
 import jax
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive

--- a/jax2onnx/plugins/jax/lax/clz.py
+++ b/jax2onnx/plugins/jax/lax/clz.py
@@ -7,7 +7,7 @@ from typing import Any
 import jax
 import numpy as np
 import onnx_ir as ir
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
@@ -96,7 +96,7 @@ _DTYPE_INFO: dict[
 class ClzPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.clz`` via explicit leading-bit scan in ONNX."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         in_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/complex.py
+++ b/jax2onnx/plugins/jax/lax/complex.py
@@ -13,6 +13,7 @@ from jax2onnx.plugins._complex_utils import (
     resolve_common_real_dtype,
 )
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -66,7 +67,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class ComplexPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.complex`` to ONNX ops, returning a packed [..., 2] tensor."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (real_var, imag_var) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/lax/complex.py
+++ b/jax2onnx/plugins/jax/lax/complex.py
@@ -13,7 +13,7 @@ from jax2onnx.plugins._complex_utils import (
     resolve_common_real_dtype,
 )
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/cos.py
+++ b/jax2onnx/plugins/jax/lax/cos.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/cos.py
+++ b/jax2onnx/plugins/jax/lax/cos.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -39,7 +39,7 @@ from jax2onnx.plugins._ir_shapes import _stamp_type_and_shape
     ],
 )
 class CosPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/cosh.py
+++ b/jax2onnx/plugins/jax/lax/cosh.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -44,7 +44,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class CoshPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/cosh.py
+++ b/jax2onnx/plugins/jax/lax/cosh.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/eq.py
+++ b/jax2onnx/plugins/jax/lax/eq.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/eq.py
+++ b/jax2onnx/plugins/jax/lax/eq.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -37,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class EqPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/erf.py
+++ b/jax2onnx/plugins/jax/lax/erf.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/erf.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class ErfPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/erf.py
+++ b/jax2onnx/plugins/jax/lax/erf.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/erf.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/erf_inv.py
+++ b/jax2onnx/plugins/jax/lax/erf_inv.py
@@ -6,7 +6,7 @@ import numpy as np
 import onnx_ir as ir
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy

--- a/jax2onnx/plugins/jax/lax/erf_inv.py
+++ b/jax2onnx/plugins/jax/lax/erf_inv.py
@@ -6,7 +6,7 @@ import numpy as np
 import onnx_ir as ir
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
@@ -62,7 +62,7 @@ class ErfInvPlugin(PrimitiveLeafPlugin):
         if getattr(ref, "shape", None) is not None:
             value.shape = ref.shape
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/erfc.py
+++ b/jax2onnx/plugins/jax/lax/erfc.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy

--- a/jax2onnx/plugins/jax/lax/erfc.py
+++ b/jax2onnx/plugins/jax/lax/erfc.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
@@ -37,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class ErfcPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.erfc`` to ONNX via ``1 - Erf(x)``."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/exp.py
+++ b/jax2onnx/plugins/jax/lax/exp.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/exp.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class ExpPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/exp.py
+++ b/jax2onnx/plugins/jax/lax/exp.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/exp.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/exp2.py
+++ b/jax2onnx/plugins/jax/lax/exp2.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy

--- a/jax2onnx/plugins/jax/lax/exp2.py
+++ b/jax2onnx/plugins/jax/lax/exp2.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
@@ -33,7 +33,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class Exp2Plugin(PrimitiveLeafPlugin):
     """Lower ``lax.exp2`` to ONNX ``Pow`` as ``2^x``."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/expm1.py
+++ b/jax2onnx/plugins/jax/lax/expm1.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy

--- a/jax2onnx/plugins/jax/lax/expm1.py
+++ b/jax2onnx/plugins/jax/lax/expm1.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class Expm1Plugin(PrimitiveLeafPlugin):
     """Lower ``lax.expm1`` to ONNX via Exp + Sub."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/floor.py
+++ b/jax2onnx/plugins/jax/lax/floor.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class FloorPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/floor.py
+++ b/jax2onnx/plugins/jax/lax/floor.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG

--- a/jax2onnx/plugins/jax/lax/fori_loop.py
+++ b/jax2onnx/plugins/jax/lax/fori_loop.py
@@ -32,7 +32,7 @@ from jax2onnx.plugins.jax.lax.scan import (
     _jaxpr_contains_scatter,
     _static_scatter_extent,
 )
-from jax2onnx.plugins.jax._jax_compat import Primitive
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/fori_loop.py
+++ b/jax2onnx/plugins/jax/lax/fori_loop.py
@@ -11,7 +11,6 @@ import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
 from jax import tree_util
-from jax.extend.core import Primitive
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
@@ -33,6 +32,7 @@ from jax2onnx.plugins.jax.lax.scan import (
     _jaxpr_contains_scatter,
     _static_scatter_extent,
 )
+from jax2onnx.plugins.jax._jax_compat import Primitive
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/ge.py
+++ b/jax2onnx/plugins/jax/lax/ge.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -37,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class GePlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/ge.py
+++ b/jax2onnx/plugins/jax/lax/ge.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/gt.py
+++ b/jax2onnx/plugins/jax/lax/gt.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -37,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class GtPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/gt.py
+++ b/jax2onnx/plugins/jax/lax/gt.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/is_finite.py
+++ b/jax2onnx/plugins/jax/lax/is_finite.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -47,7 +47,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class IsFinitePlugin(PrimitiveLeafPlugin):
     """Lower ``lax.is_finite`` to ONNX via IsInf + IsNaN + Or + Not."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/is_finite.py
+++ b/jax2onnx/plugins/jax/lax/is_finite.py
@@ -3,7 +3,7 @@
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG

--- a/jax2onnx/plugins/jax/lax/le.py
+++ b/jax2onnx/plugins/jax/lax/le.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class LePlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/le.py
+++ b/jax2onnx/plugins/jax/lax/le.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/log.py
+++ b/jax2onnx/plugins/jax/lax/log.py
@@ -1,6 +1,6 @@
 # jax2onnx/plugins/jax/lax/log.py
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -72,7 +72,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class LogPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/log.py
+++ b/jax2onnx/plugins/jax/lax/log.py
@@ -1,6 +1,6 @@
 # jax2onnx/plugins/jax/lax/log.py
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/log1p.py
+++ b/jax2onnx/plugins/jax/lax/log1p.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/log1p.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/log1p.py
+++ b/jax2onnx/plugins/jax/lax/log1p.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/log1p.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -36,7 +36,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class Log1pPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.log1p`` to ONNX via Add + Log."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/logistic.py
+++ b/jax2onnx/plugins/jax/lax/logistic.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/logistic.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class LogisticPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/logistic.py
+++ b/jax2onnx/plugins/jax/lax/logistic.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/logistic.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/lt.py
+++ b/jax2onnx/plugins/jax/lax/lt.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -37,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class LtPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/lt.py
+++ b/jax2onnx/plugins/jax/lax/lt.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/max.py
+++ b/jax2onnx/plugins/jax/lax/max.py
@@ -8,6 +8,7 @@ import jax
 import numpy as np
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -36,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class MaxPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: Any, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: Any, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/max.py
+++ b/jax2onnx/plugins/jax/lax/max.py
@@ -8,7 +8,7 @@ import jax
 import numpy as np
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/min.py
+++ b/jax2onnx/plugins/jax/lax/min.py
@@ -8,7 +8,7 @@ import jax
 import numpy as np
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/min.py
+++ b/jax2onnx/plugins/jax/lax/min.py
@@ -8,6 +8,7 @@ import jax
 import numpy as np
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -36,7 +37,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class MinPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: Any, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: Any, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/mul.py
+++ b/jax2onnx/plugins/jax/lax/mul.py
@@ -28,6 +28,7 @@ from jax2onnx.plugins._complex_utils import (
 )
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -126,7 +127,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class MulPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/mul.py
+++ b/jax2onnx/plugins/jax/lax/mul.py
@@ -28,7 +28,7 @@ from jax2onnx.plugins._complex_utils import (
 )
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/ne.py
+++ b/jax2onnx/plugins/jax/lax/ne.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/ne.py
+++ b/jax2onnx/plugins/jax/lax/ne.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -41,7 +41,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class NePlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/neg.py
+++ b/jax2onnx/plugins/jax/lax/neg.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/neg.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/neg.py
+++ b/jax2onnx/plugins/jax/lax/neg.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/neg.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -30,7 +30,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class NegPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/or.py
+++ b/jax2onnx/plugins/jax/lax/or.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 import jax
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 

--- a/jax2onnx/plugins/jax/lax/or.py
+++ b/jax2onnx/plugins/jax/lax/or.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 
@@ -59,7 +59,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class OrPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.bitwise_or`` and boolean ``or``."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/population_count.py
+++ b/jax2onnx/plugins/jax/lax/population_count.py
@@ -7,7 +7,7 @@ from typing import Any
 import jax
 import numpy as np
 import onnx_ir as ir
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
@@ -96,7 +96,7 @@ _DTYPE_INFO: dict[
 class PopulationCountPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.population_count`` via per-bit popcount accumulation."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         in_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/population_count.py
+++ b/jax2onnx/plugins/jax/lax/population_count.py
@@ -7,7 +7,7 @@ from typing import Any
 import jax
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive

--- a/jax2onnx/plugins/jax/lax/remat2.py
+++ b/jax2onnx/plugins/jax/lax/remat2.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import Primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import lower_jaxpr_eqns
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
@@ -26,21 +27,7 @@ def _init_remat2_primitive() -> Any | None:
     if existing is not None:
         existing.multiple_results = True
         return existing
-    base_core: Any | None = None
-    try:  # pragma: no cover
-        from jax.extend import core as jax_core_ext
-
-        base_core = jax_core_ext
-    except ImportError:  # pragma: no cover
-        try:
-            from jax import core as jax_core
-
-            base_core = jax_core
-        except ImportError:
-            base_core = None
-    if base_core is None:
-        return None
-    remat2 = base_core.Primitive("remat2")
+    remat2 = Primitive("remat2")
     remat2.multiple_results = True
     setattr(lax, "remat2_p", remat2)
     return remat2

--- a/jax2onnx/plugins/jax/lax/remat2.py
+++ b/jax2onnx/plugins/jax/lax/remat2.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import Primitive
+from jax2onnx._compat.jax import Primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import lower_jaxpr_eqns
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 

--- a/jax2onnx/plugins/jax/lax/round.py
+++ b/jax2onnx/plugins/jax/lax/round.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/round.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/round.py
+++ b/jax2onnx/plugins/jax/lax/round.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/round.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -34,7 +34,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class RoundPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/rsqrt.py
+++ b/jax2onnx/plugins/jax/lax/rsqrt.py
@@ -11,6 +11,7 @@ import onnx_ir as ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -38,7 +39,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 )
 class RsqrtPlugin(PrimitiveLeafPlugin):
     def lower(
-        self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn
+        self, ctx: LoweringContextProtocol, eqn: JaxprEqn
     ) -> None:  # pragma: no cover - exercised via tests
         builder = ctx.builder
 

--- a/jax2onnx/plugins/jax/lax/rsqrt.py
+++ b/jax2onnx/plugins/jax/lax/rsqrt.py
@@ -11,7 +11,7 @@ import onnx_ir as ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/scan.py
+++ b/jax2onnx/plugins/jax/lax/scan.py
@@ -9,7 +9,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core as jax_core
 from jax import lax
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -20,6 +19,7 @@ from jax2onnx.plugins._ir_shapes import (
 )
 from jax2onnx.plugins._loop_extent_meta import set_axis0_override
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import DropVar, Var
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import (
     builder_cast,
@@ -39,8 +39,6 @@ from jax2onnx.plugins.jax.lax._index_utils import (
     _const_i64,
     _unsqueeze_scalar,
 )
-
-import jax.extend.core as jax_core_ext
 
 
 def _jaxpr_contains_scatter(jpr_like: Any) -> bool:
@@ -144,42 +142,8 @@ def _maybe_cast_value(
     return cast_val
 
 
-def _maybe_var_type(mod: Any) -> type[Any] | None:
-    if mod is None:
-        return None
-    try:
-        return cast(type[Any], getattr(mod, "Var"))
-    except AttributeError:
-        return None
-
-
-_JAX_VAR_TYPES: Final[tuple[type, ...]] = tuple(
-    t
-    for t in (
-        _maybe_var_type(jax_core),
-        _maybe_var_type(jax_core_ext),
-    )
-    if t is not None
-)
-
-
-def _maybe_dropvar_type(mod: Any) -> type[Any] | None:
-    if mod is None:
-        return None
-    try:
-        return cast(type[Any], getattr(mod, "DropVar"))
-    except AttributeError:
-        return None
-
-
-_DROP_VAR_TYPES: Final[tuple[type, ...]] = tuple(
-    t
-    for t in (
-        _maybe_dropvar_type(jax_core),
-        _maybe_dropvar_type(jax_core_ext),
-    )
-    if t is not None
-)
+_JAX_VAR_TYPES: Final[tuple[type, ...]] = (Var,)
+_DROP_VAR_TYPES: Final[tuple[type, ...]] = (DropVar,)
 
 
 def _is_dropvar(obj: Any) -> bool:

--- a/jax2onnx/plugins/jax/lax/scan.py
+++ b/jax2onnx/plugins/jax/lax/scan.py
@@ -19,7 +19,7 @@ from jax2onnx.plugins._ir_shapes import (
 )
 from jax2onnx.plugins._loop_extent_meta import set_axis0_override
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import DropVar, Var
+from jax2onnx._compat.jax import DropVar, Var
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins.jax.lax._control_flow_utils import (
     builder_cast,

--- a/jax2onnx/plugins/jax/lax/scatter_utils.py
+++ b/jax2onnx/plugins/jax/lax/scatter_utils.py
@@ -18,12 +18,12 @@ from typing import Any, Dict, Sequence, Tuple, cast
 
 import numpy as np
 import onnx_ir as ir
-from jax import core
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import const_value_to_numpy
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._loop_extent_meta import set_axis0_override
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.jax.lax._index_utils import (
     _builder_op,
     _cast_to_i64,
@@ -1566,7 +1566,7 @@ def ensure_supported_mode(mode: Any) -> None:
 
 def lower_scatter_common(
     ctx: LoweringContextProtocol,
-    eqn: core.JaxprEqn,
+    eqn: JaxprEqn,
     *,
     reduction: str,
     updates_override: ir.Value | None = None,

--- a/jax2onnx/plugins/jax/lax/scatter_utils.py
+++ b/jax2onnx/plugins/jax/lax/scatter_utils.py
@@ -23,7 +23,7 @@ from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import const_value_to_numpy
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._loop_extent_meta import set_axis0_override
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.jax.lax._index_utils import (
     _builder_op,
     _cast_to_i64,

--- a/jax2onnx/plugins/jax/lax/shift_left.py
+++ b/jax2onnx/plugins/jax/lax/shift_left.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG

--- a/jax2onnx/plugins/jax/lax/shift_left.py
+++ b/jax2onnx/plugins/jax/lax/shift_left.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -58,7 +58,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class ShiftLeftPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.shift_left`` to ONNX ``BitShift(direction='LEFT')``."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/shift_right_arithmetic.py
+++ b/jax2onnx/plugins/jax/lax/shift_right_arithmetic.py
@@ -5,7 +5,7 @@ from typing import Any
 import jax
 import numpy as np
 import onnx_ir as ir
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import numpy_dtype_to_ir
@@ -109,7 +109,7 @@ class ShiftRightArithmeticPlugin(PrimitiveLeafPlugin):
         if getattr(ref, "shape", None) is not None:
             value.shape = ref.shape
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/shift_right_arithmetic.py
+++ b/jax2onnx/plugins/jax/lax/shift_right_arithmetic.py
@@ -5,7 +5,7 @@ from typing import Any
 import jax
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import numpy_dtype_to_ir

--- a/jax2onnx/plugins/jax/lax/shift_right_logical.py
+++ b/jax2onnx/plugins/jax/lax/shift_right_logical.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG

--- a/jax2onnx/plugins/jax/lax/shift_right_logical.py
+++ b/jax2onnx/plugins/jax/lax/shift_right_logical.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -59,7 +59,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class ShiftRightLogicalPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.shift_right_logical`` to ONNX BitShift(direction="RIGHT")."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/sign.py
+++ b/jax2onnx/plugins/jax/lax/sign.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/sign.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class SignPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/sign.py
+++ b/jax2onnx/plugins/jax/lax/sign.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/sign.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/sin.py
+++ b/jax2onnx/plugins/jax/lax/sin.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/sin.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class SinPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/sin.py
+++ b/jax2onnx/plugins/jax/lax/sin.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/sin.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/sinh.py
+++ b/jax2onnx/plugins/jax/lax/sinh.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 import numpy as np
 
@@ -44,7 +44,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class SinhPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/sinh.py
+++ b/jax2onnx/plugins/jax/lax/sinh.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 import numpy as np
 

--- a/jax2onnx/plugins/jax/lax/sqrt.py
+++ b/jax2onnx/plugins/jax/lax/sqrt.py
@@ -1,6 +1,6 @@
 # jax2onnx/plugins/jax/lax/sqrt.py
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -54,7 +54,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class SqrtPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/sqrt.py
+++ b/jax2onnx/plugins/jax/lax/sqrt.py
@@ -1,6 +1,6 @@
 # jax2onnx/plugins/jax/lax/sqrt.py
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/square.py
+++ b/jax2onnx/plugins/jax/lax/square.py
@@ -1,6 +1,6 @@
 # jax2onnx/plugins/jax/lax/square.py
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -40,7 +40,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class SquarePlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/square.py
+++ b/jax2onnx/plugins/jax/lax/square.py
@@ -1,6 +1,6 @@
 # jax2onnx/plugins/jax/lax/square.py
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/sub.py
+++ b/jax2onnx/plugins/jax/lax/sub.py
@@ -27,7 +27,7 @@ from jax2onnx.plugins._complex_utils import (
 )
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/lax/sub.py
+++ b/jax2onnx/plugins/jax/lax/sub.py
@@ -27,6 +27,7 @@ from jax2onnx.plugins._complex_utils import (
 )
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -124,7 +125,7 @@ def _lower_complex_sub(
     ],
 )
 class SubPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/tan.py
+++ b/jax2onnx/plugins/jax/lax/tan.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/tan.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -35,7 +35,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
     ],
 )
 class TanPlugin(PrimitiveLeafPlugin):
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/tan.py
+++ b/jax2onnx/plugins/jax/lax/tan.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/tan.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/tanh.py
+++ b/jax2onnx/plugins/jax/lax/tanh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/tanh.py
 
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -47,7 +47,7 @@ class TanhPlugin(PrimitiveLeafPlugin):
     #   - fresh_name(prefix: str) -> str
     # `eqn` is a JAX jaxpr equation with `.invars` and `.outvars`.
     # ─────────────────────────────────────────────────────────────────────────
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         """
         Lower a single jaxpr equation for tanh to onnx_ir:
             y = Tanh(x)

--- a/jax2onnx/plugins/jax/lax/tanh.py
+++ b/jax2onnx/plugins/jax/lax/tanh.py
@@ -1,7 +1,7 @@
 # jax2onnx/plugins/jax/lax/tanh.py
 
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 import jax
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/lax/transpose.py
+++ b/jax2onnx/plugins/jax/lax/transpose.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Any, List
 
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax import lax
 
 import onnx_ir as ir

--- a/jax2onnx/plugins/jax/lax/transpose.py
+++ b/jax2onnx/plugins/jax/lax/transpose.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Any, List
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax import lax
 
 import onnx_ir as ir
@@ -97,7 +97,7 @@ from jax2onnx.plugins._ir_shapes import (
 class TransposePlugin(PrimitiveLeafPlugin):
     """plugins IR converter for jax.lax.transpose → ONNX Transpose."""
 
-    def lower(self, ctx: Any, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: Any, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         y_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/xor.py
+++ b/jax2onnx/plugins/jax/lax/xor.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import numpy as np
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -54,7 +54,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 class XorPlugin(PrimitiveLeafPlugin):
     """Lower ``lax.bitwise_xor`` and boolean ``xor``."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: "core.JaxprEqn") -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/lax/xor.py
+++ b/jax2onnx/plugins/jax/lax/xor.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG

--- a/jax2onnx/plugins/jax/nn/_builder_utils.py
+++ b/jax2onnx/plugins/jax/nn/_builder_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Mapping, cast
 
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     Primitive,
     batching,
 )

--- a/jax2onnx/plugins/jax/nn/_builder_utils.py
+++ b/jax2onnx/plugins/jax/nn/_builder_utils.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import Any, Mapping, cast
 
 import onnx_ir as ir
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    Primitive,
+    batching,
+)
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _stamp_type_and_shape

--- a/jax2onnx/plugins/jax/nn/celu.py
+++ b/jax2onnx/plugins/jax/nn/celu.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/celu.py
+++ b/jax2onnx/plugins/jax/nn/celu.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -93,13 +98,11 @@ class CeluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, alpha: float = 1.0
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, alpha: float = 1.0) -> ShapedArray:
         del alpha
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         alpha = float(eqn.params.get("alpha", 1.0))
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]

--- a/jax2onnx/plugins/jax/nn/dot_product_attention.py
+++ b/jax2onnx/plugins/jax/nn/dot_product_attention.py
@@ -21,8 +21,13 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax import nn as jax_nn
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import onnx_ir as ir
 from numpy.typing import ArrayLike
 
@@ -775,16 +780,16 @@ class DotProductAttentionPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        q: jax.core.AbstractValue,
-        k: jax.core.AbstractValue,
-        v: jax.core.AbstractValue,
+        q: AbstractValue,
+        k: AbstractValue,
+        v: AbstractValue,
         *_: object,
         **__: object,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del k, v
-        return jax.core.ShapedArray(q.shape, q.dtype)
+        return ShapedArray(q.shape, q.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         invars = list(eqn.invars)
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/dot_product_attention.py
+++ b/jax2onnx/plugins/jax/nn/dot_product_attention.py
@@ -21,7 +21,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax import nn as jax_nn
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/elu.py
+++ b/jax2onnx/plugins/jax/nn/elu.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -92,13 +97,11 @@ class EluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, alpha: float = 1.0
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, alpha: float = 1.0) -> ShapedArray:
         del alpha
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         alpha = float(eqn.params.get("alpha", 1.0))
 
         lower_unary_elementwise(

--- a/jax2onnx/plugins/jax/nn/elu.py
+++ b/jax2onnx/plugins/jax/nn/elu.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/gelu.py
+++ b/jax2onnx/plugins/jax/nn/gelu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/gelu.py
+++ b/jax2onnx/plugins/jax/nn/gelu.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import ad
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+    batching,
+)
 import jax.numpy as jnp
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -102,13 +107,11 @@ class GeluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, approximate: bool = True
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, approximate: bool = True) -> ShapedArray:
         del approximate
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         approximate = bool(eqn.params.get("approximate", True))
 
         approx_attr = "tanh" if approximate else "none"

--- a/jax2onnx/plugins/jax/nn/glu.py
+++ b/jax2onnx/plugins/jax/nn/glu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/glu.py
+++ b/jax2onnx/plugins/jax/nn/glu.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -81,14 +86,12 @@ class GluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, *, axis: int = -1
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, *, axis: int = -1) -> ShapedArray:
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         out = jax.eval_shape(lambda arr: _JAX_GLU_ORIG(arr, axis=axis), spec)
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
         axis = int(eqn.params.get("axis", -1))

--- a/jax2onnx/plugins/jax/nn/hard_sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/hard_sigmoid.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -62,10 +67,10 @@ class HardSigmoidPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/hard_sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/hard_sigmoid.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/hard_swish.py
+++ b/jax2onnx/plugins/jax/nn/hard_swish.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/hard_swish.py
+++ b/jax2onnx/plugins/jax/nn/hard_swish.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -62,10 +67,10 @@ class HardSwishPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/hard_tanh.py
+++ b/jax2onnx/plugins/jax/nn/hard_tanh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/hard_tanh.py
+++ b/jax2onnx/plugins/jax/nn/hard_tanh.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -62,10 +67,10 @@ class HardTanhPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/hardmax.py
+++ b/jax2onnx/plugins/jax/nn/hardmax.py
@@ -6,9 +6,14 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import batching
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -103,13 +108,13 @@ class HardmaxPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         axis: int = -1,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         _normalize_axis(int(axis), len(x.shape))
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         axis = int(eqn.params.get("axis", -1))
 
         x_var = eqn.invars[0]

--- a/jax2onnx/plugins/jax/nn/hardmax.py
+++ b/jax2onnx/plugins/jax/nn/hardmax.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/identity.py
+++ b/jax2onnx/plugins/jax/nn/identity.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -81,10 +86,10 @@ class IdentityPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/nn/identity.py
+++ b/jax2onnx/plugins/jax/nn/identity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/initializers/truncated_normal.py
+++ b/jax2onnx/plugins/jax/nn/initializers/truncated_normal.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     Primitive,
     ShapedArray,

--- a/jax2onnx/plugins/jax/nn/initializers/truncated_normal.py
+++ b/jax2onnx/plugins/jax/nn/initializers/truncated_normal.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import numpy as np
 
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata
@@ -96,7 +99,7 @@ class TruncatedNormalPlugin(PrimitiveLeafPlugin):
         shape: tuple[int, ...],
         dtype: Any,
         **_: Any,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del key_av, lower_av, upper_av
 
         def _safe_dim(dim: Any) -> Any:
@@ -107,9 +110,9 @@ class TruncatedNormalPlugin(PrimitiveLeafPlugin):
                 return None
 
         safe_shape = tuple(_safe_dim(dim) for dim in shape)
-        return core.ShapedArray(safe_shape, dtype)
+        return ShapedArray(safe_shape, dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (out_var,) = eqn.outvars
         params = eqn.params or {}
         shape_param = tuple(params.get("shape", ()))

--- a/jax2onnx/plugins/jax/nn/leaky_relu.py
+++ b/jax2onnx/plugins/jax/nn/leaky_relu.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -97,13 +102,11 @@ class LeakyReluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, negative_slope: float = 0.01
-    ) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue, negative_slope: float = 0.01) -> ShapedArray:
         del negative_slope
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         negative_slope = float(eqn.params.get("negative_slope", 0.01))
 
         lower_unary_elementwise(

--- a/jax2onnx/plugins/jax/nn/leaky_relu.py
+++ b/jax2onnx/plugins/jax/nn/leaky_relu.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/log1mexp.py
+++ b/jax2onnx/plugins/jax/nn/log1mexp.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -69,12 +74,12 @@ class Log1mexpPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         out = jax.eval_shape(_JAX_LOG1MEXP_ORIG, spec)
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/nn/log1mexp.py
+++ b/jax2onnx/plugins/jax/nn/log1mexp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/log_sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/log_sigmoid.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -64,10 +69,10 @@ class LogSigmoidPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/log_sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/log_sigmoid.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/log_softmax.py
+++ b/jax2onnx/plugins/jax/nn/log_softmax.py
@@ -6,8 +6,13 @@ from typing import Any, Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -92,14 +97,14 @@ class LogSoftmaxPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         *,
         axis: int = -1,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del axis
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         axis_param = eqn.params.get("axis", -1)
         if isinstance(axis_param, (tuple, list)):
             if len(axis_param) != 1:

--- a/jax2onnx/plugins/jax/nn/log_softmax.py
+++ b/jax2onnx/plugins/jax/nn/log_softmax.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/logmeanexp.py
+++ b/jax2onnx/plugins/jax/nn/logmeanexp.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -103,11 +108,11 @@ class LogMeanExpPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None,
         keepdims: bool,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         axis_arg = _axis_arg(axes)
         out = jax.eval_shape(
@@ -119,9 +124,9 @@ class LogMeanExpPlugin(PrimitiveLeafPlugin):
             ),
             spec,
         )
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/nn/logmeanexp.py
+++ b/jax2onnx/plugins/jax/nn/logmeanexp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/logsumexp.py
+++ b/jax2onnx/plugins/jax/nn/logsumexp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/logsumexp.py
+++ b/jax2onnx/plugins/jax/nn/logsumexp.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -98,11 +103,11 @@ class LogSumExpPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None,
         keepdims: bool,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         axis_arg = LogSumExpPlugin._axis_arg(axes)
         out = jax.eval_shape(
@@ -116,9 +121,9 @@ class LogSumExpPlugin(PrimitiveLeafPlugin):
             ),
             spec,
         )
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/mish.py
+++ b/jax2onnx/plugins/jax/nn/mish.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -80,10 +85,10 @@ class MishPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/mish.py
+++ b/jax2onnx/plugins/jax/nn/mish.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/one_hot.py
+++ b/jax2onnx/plugins/jax/nn/one_hot.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, ClassVar, Final
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/one_hot.py
+++ b/jax2onnx/plugins/jax/nn/one_hot.py
@@ -7,8 +7,13 @@ from typing import Any, Callable, ClassVar, Final
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -68,12 +73,12 @@ class OneHotPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         *,
         num_classes: int,
         dtype: Any = jnp.float32,
         axis: int = -1,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         x_shape = tuple(getattr(x, "shape", ()))
         out_rank = len(x_shape) + 1
 
@@ -87,9 +92,9 @@ class OneHotPlugin(PrimitiveLeafPlugin):
 
         out_shape = list(x_shape)
         out_shape.insert(axis_int, int(num_classes))
-        return jax.core.ShapedArray(tuple(out_shape), np.dtype(dtype))
+        return ShapedArray(tuple(out_shape), np.dtype(dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/relu.py
+++ b/jax2onnx/plugins/jax/nn/relu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/relu.py
+++ b/jax2onnx/plugins/jax/nn/relu.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import ad
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -88,10 +93,10 @@ class ReluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/nn/relu6.py
+++ b/jax2onnx/plugins/jax/nn/relu6.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/relu6.py
+++ b/jax2onnx/plugins/jax/nn/relu6.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -62,10 +67,10 @@ class Relu6Plugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/scaled_dot_general.py
+++ b/jax2onnx/plugins/jax/nn/scaled_dot_general.py
@@ -6,8 +6,13 @@ from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -102,12 +107,12 @@ class ScaledDotGeneralPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        lhs: jax.core.AbstractValue,
-        rhs: jax.core.AbstractValue,
+        lhs: AbstractValue,
+        rhs: AbstractValue,
         *,
         dimension_numbers: DotDimensionNumbers,
         preferred_element_type: np.dtype[Any] | type[Any],
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         lhs_spec = jax.ShapeDtypeStruct(lhs.shape, lhs.dtype)
         rhs_spec = jax.ShapeDtypeStruct(rhs.shape, rhs.dtype)
         out = jax.eval_shape(
@@ -122,9 +127,9 @@ class ScaledDotGeneralPlugin(PrimitiveLeafPlugin):
             lhs_spec,
             rhs_spec,
         )
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         dimension_numbers = params.get("dimension_numbers")
         if dimension_numbers is None:

--- a/jax2onnx/plugins/jax/nn/scaled_dot_general.py
+++ b/jax2onnx/plugins/jax/nn/scaled_dot_general.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/scaled_matmul.py
+++ b/jax2onnx/plugins/jax/nn/scaled_matmul.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/scaled_matmul.py
+++ b/jax2onnx/plugins/jax/nn/scaled_matmul.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -142,13 +147,13 @@ class ScaledMatmulPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        lhs: jax.core.AbstractValue,
-        rhs: jax.core.AbstractValue,
-        lhs_scales: jax.core.AbstractValue,
-        rhs_scales: jax.core.AbstractValue,
+        lhs: AbstractValue,
+        rhs: AbstractValue,
+        lhs_scales: AbstractValue,
+        rhs_scales: AbstractValue,
         *,
         preferred_element_type: np.dtype[Any] | type[Any],
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         lhs_spec = jax.ShapeDtypeStruct(lhs.shape, lhs.dtype)
         rhs_spec = jax.ShapeDtypeStruct(rhs.shape, rhs.dtype)
         lhs_scales_spec = jax.ShapeDtypeStruct(lhs_scales.shape, lhs_scales.dtype)
@@ -166,9 +171,9 @@ class ScaledMatmulPlugin(PrimitiveLeafPlugin):
             lhs_scales_spec,
             rhs_scales_spec,
         )
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var, lhs_scales_var, rhs_scales_var = eqn.invars
         out_var = eqn.outvars[0]
         preferred_element_type = eqn.params.get("preferred_element_type", np.float32)

--- a/jax2onnx/plugins/jax/nn/selu.py
+++ b/jax2onnx/plugins/jax/nn/selu.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -81,10 +86,10 @@ class SeluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/selu.py
+++ b/jax2onnx/plugins/jax/nn/selu.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/sigmoid.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/sigmoid.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -74,10 +79,10 @@ class SigmoidPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/nn/silu.py
+++ b/jax2onnx/plugins/jax/nn/silu.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -87,10 +92,10 @@ class SiluPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/silu.py
+++ b/jax2onnx/plugins/jax/nn/silu.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/softmax.py
+++ b/jax2onnx/plugins/jax/nn/softmax.py
@@ -8,7 +8,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/softmax.py
+++ b/jax2onnx/plugins/jax/nn/softmax.py
@@ -8,8 +8,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -99,18 +104,18 @@ class SoftmaxPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
-        where: jax.core.AbstractValue | None = None,
+        x: AbstractValue,
+        where: AbstractValue | None = None,
         *,
         axis: int = -1,
         has_where: bool = False,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del axis
         if has_where and where is None:
             raise ValueError("softmax with has_where=True expects a mask operand")
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         if not eqn.invars:
             raise ValueError("softmax lowering expects at least the input tensor")
         x_var = eqn.invars[0]

--- a/jax2onnx/plugins/jax/nn/softplus.py
+++ b/jax2onnx/plugins/jax/nn/softplus.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/softplus.py
+++ b/jax2onnx/plugins/jax/nn/softplus.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -86,10 +91,10 @@ class SoftplusPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/nn/softsign.py
+++ b/jax2onnx/plugins/jax/nn/softsign.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    ad,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -85,10 +90,10 @@ class SoftsignPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/softsign.py
+++ b/jax2onnx/plugins/jax/nn/softsign.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar, Final
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/sparse_plus.py
+++ b/jax2onnx/plugins/jax/nn/sparse_plus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/sparse_plus.py
+++ b/jax2onnx/plugins/jax/nn/sparse_plus.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -74,10 +79,10 @@ class SparsePlusPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/sparse_sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/sparse_sigmoid.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/sparse_sigmoid.py
+++ b/jax2onnx/plugins/jax/nn/sparse_sigmoid.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -74,10 +79,10 @@ class SparseSigmoidPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/squareplus.py
+++ b/jax2onnx/plugins/jax/nn/squareplus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/squareplus.py
+++ b/jax2onnx/plugins/jax/nn/squareplus.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -67,17 +72,17 @@ class SquareplusPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
-        b: jax.core.AbstractValue,
-    ) -> jax.core.ShapedArray:
+        x: AbstractValue,
+        b: AbstractValue,
+    ) -> ShapedArray:
         x_spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         b_spec = jax.ShapeDtypeStruct(b.shape, b.dtype)
         out = jax.eval_shape(
             lambda xv, bv: _JAX_SQUAREPLUS_ORIG(xv, b=bv), x_spec, b_spec
         )
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, b_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/nn/standardize.py
+++ b/jax2onnx/plugins/jax/nn/standardize.py
@@ -9,7 +9,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -94,15 +99,15 @@ class StandardizePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         *,
         axis: tuple[int, ...] | None = None,
         epsilon: float = 0.0,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del axis, epsilon
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/nn/standardize.py
+++ b/jax2onnx/plugins/jax/nn/standardize.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/tanh.py
+++ b/jax2onnx/plugins/jax/nn/tanh.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -63,10 +68,10 @@ class TanhPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/nn/tanh.py
+++ b/jax2onnx/plugins/jax/nn/tanh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/nn/thresholded_relu.py
+++ b/jax2onnx/plugins/jax/nn/thresholded_relu.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, Final
 
-import jax
 import jax.numpy as jnp
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -74,13 +78,13 @@ class ThresholdedReluPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         threshold: float = 1.0,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del threshold
-        return jax.core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         threshold = float(eqn.params.get("threshold", 1.0))
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]

--- a/jax2onnx/plugins/jax/nn/thresholded_relu.py
+++ b/jax2onnx/plugins/jax/nn/thresholded_relu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/numpy/_common.py
+++ b/jax2onnx/plugins/jax/numpy/_common.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, cast
 
-from jax.extend.core import Primitive
-
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
+from jax2onnx.plugins.jax._jax_compat import Primitive
 
 
 BoundCallable = Callable[..., Any]

--- a/jax2onnx/plugins/jax/numpy/_common.py
+++ b/jax2onnx/plugins/jax/numpy/_common.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, cast
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
-from jax2onnx.plugins.jax._jax_compat import Primitive
+from jax2onnx._compat.jax import Primitive
 
 
 BoundCallable = Callable[..., Any]

--- a/jax2onnx/plugins/jax/numpy/_reduction_utils.py
+++ b/jax2onnx/plugins/jax/numpy/_reduction_utils.py
@@ -7,9 +7,12 @@ from collections.abc import Sequence
 from typing import Any, TypeAlias
 
 import jax
-from jax import core
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import numpy as np
 
 from jax2onnx.plugins.jax.numpy._common import get_orig_impl
@@ -39,14 +42,14 @@ def axis_arg_from_params(
 def abstract_eval_via_orig_reduction(
     prim: Primitive,
     func_name: str,
-    x: core.AbstractValue,
+    x: AbstractValue,
     *,
     axes: tuple[int, ...] | None = None,
     axes_is_tuple: bool = False,
     dtype: np.dtype[np.generic] | type | None = None,
     keepdims: bool = False,
     promote_integers: bool = True,
-) -> core.ShapedArray:
+) -> ShapedArray:
     """Mirror JAX reduction semantics by delegating to original jnp callable."""
     shape = tuple(getattr(x, "shape", ()))
     in_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -67,7 +70,7 @@ def abstract_eval_via_orig_reduction(
     out = jax.eval_shape(lambda v: orig(v, **kwargs), shape_dtype)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", in_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def register_reduction_batch_rule(prim: Primitive, lax_prim: Primitive) -> None:

--- a/jax2onnx/plugins/jax/numpy/_reduction_utils.py
+++ b/jax2onnx/plugins/jax/numpy/_reduction_utils.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from typing import Any, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     Primitive,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/_unary_utils.py
+++ b/jax2onnx/plugins/jax/numpy/_unary_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/numpy/_unary_utils.py
+++ b/jax2onnx/plugins/jax/numpy/_unary_utils.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from typing import Any, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.extend.core import Primitive
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import numpy as np
 import onnx_ir as ir
 
@@ -20,8 +24,8 @@ from jax2onnx.plugins.jax.numpy._common import get_orig_impl
 def abstract_eval_via_orig_unary(
     prim: Primitive,
     func_name: str,
-    x: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+) -> ShapedArray:
     """Mirror JAX dtype/shape semantics by delegating to the original jnp impl."""
     shape = tuple(getattr(x, "shape", ()))
     dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -30,12 +34,12 @@ def abstract_eval_via_orig_unary(
     out = jax.eval_shape(lambda v: orig(v), shape_dtype)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def lower_unary_elementwise_with_optional_cast(
     ctx: LoweringContextProtocol,
-    eqn: core.JaxprEqn,
+    eqn: JaxprEqn,
     *,
     op_name: str,
     input_hint: str,
@@ -108,8 +112,8 @@ def lower_unary_elementwise_with_optional_cast(
 
 def cast_input_to_output_dtype(
     ctx: LoweringContextProtocol,
-    x_var: core.AbstractValue,
-    y_var: core.AbstractValue,
+    x_var: AbstractValue,
+    y_var: AbstractValue,
     x_val: ir.Value,
     *,
     output_hint: str,

--- a/jax2onnx/plugins/jax/numpy/abs.py
+++ b/jax2onnx/plugins/jax/numpy/abs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/abs.py
+++ b/jax2onnx/plugins/jax/numpy/abs.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -80,12 +84,12 @@ class JnpAbsPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAbsPlugin._PRIM, JnpAbsPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/acos.py
+++ b/jax2onnx/plugins/jax/numpy/acos.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -88,12 +92,12 @@ class JnpAcosPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAcosPlugin._PRIM, JnpAcosPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/acos.py
+++ b/jax2onnx/plugins/jax/numpy/acos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/acosh.py
+++ b/jax2onnx/plugins/jax/numpy/acosh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/acosh.py
+++ b/jax2onnx/plugins/jax/numpy/acosh.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -90,12 +94,12 @@ class JnpAcoshPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAcoshPlugin._PRIM, JnpAcoshPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/add.py
+++ b/jax2onnx/plugins/jax/numpy/add.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/add.py
+++ b/jax2onnx/plugins/jax/numpy/add.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.interpreters import batching
 from jax2onnx.plugins.jax.lax.add import lower_add
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -91,12 +95,12 @@ class JnpAddPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
         out_dtype = np.promote_types(x.dtype, y.dtype)
-        return jax.core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_add(ctx, eqn)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/all.py
+++ b/jax2onnx/plugins/jax/numpy/all.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/all.py
+++ b/jax2onnx/plugins/jax/numpy/all.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -75,12 +79,12 @@ class JnpAllPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         keepdims: bool = False,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpAllPlugin._PRIM,
             JnpAllPlugin._FUNC_NAME,
@@ -90,7 +94,7 @@ class JnpAllPlugin(PrimitiveLeafPlugin):
             keepdims=keepdims,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_boolean_reduction(ctx, eqn, mode="reduce_and")
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/amax.py
+++ b/jax2onnx/plugins/jax/numpy/amax.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/amax.py
+++ b/jax2onnx/plugins/jax/numpy/amax.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -87,12 +91,12 @@ class JnpAmaxPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         keepdims: bool = False,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpAmaxPlugin._PRIM,
             JnpAmaxPlugin._FUNC_NAME,
@@ -102,7 +106,7 @@ class JnpAmaxPlugin(PrimitiveLeafPlugin):
             keepdims=keepdims,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_reduction(ctx, eqn, op_type="ReduceMax", allow_dtype_param=False)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/amin.py
+++ b/jax2onnx/plugins/jax/numpy/amin.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/amin.py
+++ b/jax2onnx/plugins/jax/numpy/amin.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -87,12 +91,12 @@ class JnpAminPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         keepdims: bool = False,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpAminPlugin._PRIM,
             JnpAminPlugin._FUNC_NAME,
@@ -102,7 +106,7 @@ class JnpAminPlugin(PrimitiveLeafPlugin):
             keepdims=keepdims,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_reduction(ctx, eqn, op_type="ReduceMin", allow_dtype_param=False)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/any.py
+++ b/jax2onnx/plugins/jax/numpy/any.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/any.py
+++ b/jax2onnx/plugins/jax/numpy/any.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -75,12 +79,12 @@ class JnpAnyPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         keepdims: bool = False,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpAnyPlugin._PRIM,
             JnpAnyPlugin._FUNC_NAME,
@@ -90,7 +94,7 @@ class JnpAnyPlugin(PrimitiveLeafPlugin):
             keepdims=keepdims,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_boolean_reduction(ctx, eqn, mode="reduce_or")
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/arange.py
+++ b/jax2onnx/plugins/jax/numpy/arange.py
@@ -8,8 +8,14 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core
-from jax.extend.core import Literal as JaxLiteral
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Literal,
+    ShapedArray,
+    Tracer,
+    dim_constant,
+)
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import numpy_dtype_to_ir
@@ -119,7 +125,7 @@ class _DynamicDimSentinel:
     def dimension_as_value(self) -> Any:  # pragma: no cover - compatibility helper
         if _SYMBOLIC_DYNAMIC_DIM is not None:
             return _SYMBOLIC_DYNAMIC_DIM.dimension_as_value()
-        return core.dim_constant(1)
+        return dim_constant(1)
 
 
 DATA_DEPENDENT_DYNAMIC_DIM: Final[_DynamicDimSentinel] = _DynamicDimSentinel()
@@ -128,7 +134,7 @@ DATA_DEPENDENT_DYNAMIC_DIM: Final[_DynamicDimSentinel] = _DynamicDimSentinel()
 _ARANGE_PRIM: Final = make_jnp_primitive("jax.numpy.arange")
 
 
-def _as_scalar(aval: core.AbstractValue | JaxLiteral | None) -> float | int | None:
+def _as_scalar(aval: AbstractValue | Literal | None) -> float | int | None:
     """Best-effort extraction of a scalar literal from an abstract value."""
     if aval is None:
         return None
@@ -147,7 +153,7 @@ def _as_scalar(aval: core.AbstractValue | JaxLiteral | None) -> float | int | No
 
 
 def _static_scalar(value: object) -> float | int | None:
-    if isinstance(value, (core.Tracer, jax.Array)):
+    if isinstance(value, (Tracer, jax.Array)):
         return None
     try:
         arr = np.asarray(value)
@@ -164,11 +170,11 @@ def _static_scalar(value: object) -> float | int | None:
 
 
 def _all_scalars(
-    avals: Sequence[core.AbstractValue | JaxLiteral | None],
+    avals: Sequence[AbstractValue | Literal | None],
 ) -> list[float | int] | None:
     scalars: list[float | int] = []
     for aval in avals:
-        if isinstance(aval, JaxLiteral):
+        if isinstance(aval, Literal):
             arr = np.asarray(aval.val)
             if arr.shape:
                 return None
@@ -211,7 +217,7 @@ def _determine_length(values: Sequence[float | int]) -> int | None:
 
 
 def _resolve_result_dtype(
-    avals: Sequence[core.AbstractValue | JaxLiteral | None],
+    avals: Sequence[AbstractValue | Literal | None],
     dtype_param: np.dtype[Any] | type | None,
     enable_x64: bool,
 ) -> np.dtype[Any]:
@@ -628,10 +634,10 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        *in_avals: core.AbstractValue,
+        *in_avals: AbstractValue,
         dtype: np.dtype[Any] | type | None = None,
         static_args: tuple[float | int | None, ...] | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         enable_x64 = bool(jax.config.jax_enable_x64)
         result_dtype = _resolve_result_dtype(in_avals, dtype, enable_x64)
         scalars = None
@@ -648,14 +654,14 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
                 DATA_DEPENDENT_DYNAMIC_DIM if length is None else int(length)
             )
             shape = (length_dim,)
-        return jax.core.ShapedArray(shape, result_dtype)
+        return ShapedArray(shape, result_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         dtype_param = params.get("dtype")
-        avals: list[core.AbstractValue | JaxLiteral | None] = []
+        avals: list[AbstractValue | Literal | None] = []
         for var in eqn.invars:
-            if isinstance(var, JaxLiteral):
+            if isinstance(var, Literal):
                 avals.append(var.aval)
             else:
                 avals.append(getattr(var, "aval", None))
@@ -690,7 +696,7 @@ class JnpArangePlugin(PrimitiveLeafPlugin):
             input_vals.append(
                 _maybe_cast_value(ctx, val, range_enum, f"arange_cast_{idx}")
             )
-            if literal_args is not None and isinstance(var, JaxLiteral):
+            if literal_args is not None and isinstance(var, Literal):
                 literal_value = cast(float | int, np.asarray(var.val).item())
                 literal_args.append(literal_value)
             else:

--- a/jax2onnx/plugins/jax/numpy/arange.py
+++ b/jax2onnx/plugins/jax/numpy/arange.py
@@ -8,7 +8,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Literal,

--- a/jax2onnx/plugins/jax/numpy/argmax.py
+++ b/jax2onnx/plugins/jax/numpy/argmax.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/argmax.py
+++ b/jax2onnx/plugins/jax/numpy/argmax.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -69,13 +73,13 @@ class JnpArgmaxPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
+        a: AbstractValue,
         *,
         axes: tuple[int, ...],
         keepdims: bool,
         index_dtype: np.dtype[Any],
         select_last_index: int,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del index_dtype, select_last_index
         orig = get_orig_impl(JnpArgmaxPlugin._PRIM, JnpArgmaxPlugin._FUNC_NAME)
         axis = int(axes[0])
@@ -83,9 +87,9 @@ class JnpArgmaxPlugin(PrimitiveLeafPlugin):
         out = jax.eval_shape(
             lambda x: orig(x, axis=axis, keepdims=keepdims), shape_dtype
         )
-        return core.ShapedArray(tuple(out.shape), np.dtype(out.dtype))
+        return ShapedArray(tuple(out.shape), np.dtype(out.dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_arg_reduction(ctx, eqn, op_name="ArgMax", name_prefix="jnp_argmax")
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/argmin.py
+++ b/jax2onnx/plugins/jax/numpy/argmin.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -64,13 +68,13 @@ class JnpArgminPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
+        a: AbstractValue,
         *,
         axes: tuple[int, ...],
         keepdims: bool,
         index_dtype: np.dtype[Any],
         select_last_index: int,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del index_dtype, select_last_index
         orig = get_orig_impl(JnpArgminPlugin._PRIM, JnpArgminPlugin._FUNC_NAME)
         axis = int(axes[0])
@@ -78,9 +82,9 @@ class JnpArgminPlugin(PrimitiveLeafPlugin):
         out = jax.eval_shape(
             lambda x: orig(x, axis=axis, keepdims=keepdims), shape_dtype
         )
-        return core.ShapedArray(tuple(out.shape), np.dtype(out.dtype))
+        return ShapedArray(tuple(out.shape), np.dtype(out.dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_arg_reduction(ctx, eqn, op_name="ArgMin", name_prefix="jnp_argmin")
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/argmin.py
+++ b/jax2onnx/plugins/jax/numpy/argmin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/asin.py
+++ b/jax2onnx/plugins/jax/numpy/asin.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -88,12 +92,12 @@ class JnpAsinPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAsinPlugin._PRIM, JnpAsinPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/asin.py
+++ b/jax2onnx/plugins/jax/numpy/asin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/asinh.py
+++ b/jax2onnx/plugins/jax/numpy/asinh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/asinh.py
+++ b/jax2onnx/plugins/jax/numpy/asinh.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -83,12 +87,12 @@ class JnpAsinhPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAsinhPlugin._PRIM, JnpAsinhPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/atan.py
+++ b/jax2onnx/plugins/jax/numpy/atan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/atan.py
+++ b/jax2onnx/plugins/jax/numpy/atan.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -83,12 +87,12 @@ class JnpAtanPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAtanPlugin._PRIM, JnpAtanPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/atan2.py
+++ b/jax2onnx/plugins/jax/numpy/atan2.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/atan2.py
+++ b/jax2onnx/plugins/jax/numpy/atan2.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -30,9 +34,9 @@ _ATAN2_PRIM: Final = make_jnp_primitive("jax.numpy.atan2")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -43,7 +47,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 @register_primitive(
@@ -104,9 +108,9 @@ class JnpAtan2Plugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpAtan2Plugin._PRIM,
             JnpAtan2Plugin._FUNC_NAME,
@@ -114,7 +118,7 @@ class JnpAtan2Plugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         LaxAtan2Plugin().lower(ctx, eqn)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/atanh.py
+++ b/jax2onnx/plugins/jax/numpy/atanh.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -90,12 +94,12 @@ class JnpAtanhPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpAtanhPlugin._PRIM, JnpAtanhPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/atanh.py
+++ b/jax2onnx/plugins/jax/numpy/atanh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_and.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_and.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_and.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_and.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -31,9 +35,9 @@ _BITWISE_AND_PRIM: Final = make_jnp_primitive("jax.numpy.bitwise_and")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.int32))
@@ -44,7 +48,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -151,9 +155,9 @@ class JnpBitwiseAndPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpBitwiseAndPlugin._PRIM,
             JnpBitwiseAndPlugin._FUNC_NAME,
@@ -161,7 +165,7 @@ class JnpBitwiseAndPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/bitwise_left_shift.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_left_shift.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -83,9 +87,9 @@ class JnpBitwiseLeftShiftPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return abstract_eval_via_orig_binary(
             JnpBitwiseLeftShiftPlugin._PRIM,
             JnpBitwiseLeftShiftPlugin._FUNC_NAME,
@@ -93,7 +97,7 @@ class JnpBitwiseLeftShiftPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_left_shift_core(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/bitwise_left_shift.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_left_shift.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_not.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_not.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -78,14 +82,14 @@ class JnpBitwiseNotPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpBitwiseNotPlugin._PRIM,
             JnpBitwiseNotPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/bitwise_not.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_not.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_or.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_or.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_or.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_or.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -31,9 +35,9 @@ _BITWISE_OR_PRIM: Final = make_jnp_primitive("jax.numpy.bitwise_or")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.int32))
@@ -44,7 +48,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -151,9 +155,9 @@ class JnpBitwiseOrPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpBitwiseOrPlugin._PRIM,
             JnpBitwiseOrPlugin._FUNC_NAME,
@@ -161,7 +165,7 @@ class JnpBitwiseOrPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/bitwise_right_shift.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_right_shift.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -83,9 +87,9 @@ class JnpBitwiseRightShiftPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return abstract_eval_via_orig_binary(
             JnpBitwiseRightShiftPlugin._PRIM,
             JnpBitwiseRightShiftPlugin._FUNC_NAME,
@@ -93,7 +97,7 @@ class JnpBitwiseRightShiftPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_right_shift_core(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/bitwise_right_shift.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_right_shift.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_xor.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_xor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/bitwise_xor.py
+++ b/jax2onnx/plugins/jax/numpy/bitwise_xor.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -31,9 +35,9 @@ _BITWISE_XOR_PRIM: Final = make_jnp_primitive("jax.numpy.bitwise_xor")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.int32))
@@ -44,7 +48,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -151,9 +155,9 @@ class JnpBitwiseXorPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpBitwiseXorPlugin._PRIM,
             JnpBitwiseXorPlugin._FUNC_NAME,
@@ -161,7 +165,7 @@ class JnpBitwiseXorPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/ceil.py
+++ b/jax2onnx/plugins/jax/numpy/ceil.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/ceil.py
+++ b/jax2onnx/plugins/jax/numpy/ceil.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -84,14 +88,14 @@ class JnpCeilPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpCeilPlugin._PRIM,
             JnpCeilPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/clip.py
+++ b/jax2onnx/plugins/jax/numpy/clip.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
 import jax.extend.core as jax_core_ext
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/clip.py
+++ b/jax2onnx/plugins/jax/numpy/clip.py
@@ -7,9 +7,13 @@ from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
 import jax.extend.core as jax_core_ext
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
-from jax.interpreters import batching as jax_batching
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
 import onnx_ir as ir
@@ -207,14 +211,14 @@ class JnpClipPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        a_min: core.AbstractValue,
-        a_max: core.AbstractValue,
+        x: AbstractValue,
+        a_min: AbstractValue,
+        a_max: AbstractValue,
         **_: object,
-    ) -> core.ShapedArray:
-        return jax.core.ShapedArray(x.shape, x.dtype)
+    ) -> ShapedArray:
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, lo_var, hi_var = eqn.invars
         out_var = eqn.outvars[0]
 
@@ -337,4 +341,4 @@ def _clip_batching_rule(args: tuple[Any, ...], dims: tuple[Any, ...]) -> Any:
     return broadcast_batcher_compat(JnpClipPlugin._PRIM, args, dims)
 
 
-jax_batching.primitive_batchers[JnpClipPlugin._PRIM] = _clip_batching_rule
+batching.primitive_batchers[JnpClipPlugin._PRIM] = _clip_batching_rule

--- a/jax2onnx/plugins/jax/numpy/clip.py
+++ b/jax2onnx/plugins/jax/numpy/clip.py
@@ -6,11 +6,12 @@ from collections.abc import Callable
 from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
-import jax.extend.core as jax_core_ext
 from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
+    Literal,
     ShapedArray,
+    Var,
     batching,
 )
 import jax.numpy as jnp
@@ -32,7 +33,7 @@ from jax2onnx.plugins.jax._batching_utils import broadcast_batcher_compat
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 ScalarBound = bool | int | float | np.generic
-JaxValue: TypeAlias = jax_core_ext.Var | jax_core_ext.Literal
+JaxValue: TypeAlias = Var | Literal
 
 
 def _np_dtype(x: DTypeLike) -> np.dtype[Any]:

--- a/jax2onnx/plugins/jax/numpy/composite_metadata.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -24,7 +26,7 @@ class _JnpCompositeMetadataPlugin(PrimitiveLeafPlugin):
         specs: list[AssignSpec | MonkeyPatchSpec] = []
         return specs
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         del ctx, eqn
         raise NotImplementedError(
             "Metadata-only jnp composite plugin should not appear in jaxpr."

--- a/jax2onnx/plugins/jax/numpy/composite_metadata.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
 )
 import jax.numpy as jnp

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch2.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch2.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -24,7 +26,7 @@ class _JnpCompositeMetadataBatch2Plugin(PrimitiveLeafPlugin):
         specs: list[AssignSpec | MonkeyPatchSpec] = []
         return specs
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         del ctx, eqn
         raise NotImplementedError(
             "Metadata-only jnp composite plugin should not appear in jaxpr."

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch2.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch2.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
 )
 import jax.numpy as jnp

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch3.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch3.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
 )
 import jax.numpy as jnp

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch3.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch3.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -24,7 +26,7 @@ class _JnpCompositeMetadataBatch3Plugin(PrimitiveLeafPlugin):
         specs: list[AssignSpec | MonkeyPatchSpec] = []
         return specs
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         del ctx, eqn
         raise NotImplementedError(
             "Metadata-only jnp composite plugin should not appear in jaxpr."

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch4.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch4.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -24,7 +26,7 @@ class _JnpCompositeMetadataBatch4Plugin(PrimitiveLeafPlugin):
         specs: list[AssignSpec | MonkeyPatchSpec] = []
         return specs
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         del ctx, eqn
         raise NotImplementedError(
             "Metadata-only jnp composite plugin should not appear in jaxpr."

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch4.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch4.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
 )
 import jax.numpy as jnp

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch5.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch5.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -24,7 +26,7 @@ class _JnpCompositeMetadataBatch5Plugin(PrimitiveLeafPlugin):
         specs: list[AssignSpec | MonkeyPatchSpec] = []
         return specs
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         del ctx, eqn
         raise NotImplementedError(
             "Metadata-only jnp composite plugin should not appear in jaxpr."

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch5.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch5.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
 )
 import jax.numpy as jnp

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch6.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch6.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -24,7 +26,7 @@ class _JnpCompositeMetadataBatch6Plugin(PrimitiveLeafPlugin):
         specs: list[AssignSpec | MonkeyPatchSpec] = []
         return specs
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         del ctx, eqn
         raise NotImplementedError(
             "Metadata-only jnp composite plugin should not appear in jaxpr."

--- a/jax2onnx/plugins/jax/numpy/composite_metadata_batch6.py
+++ b/jax2onnx/plugins/jax/numpy/composite_metadata_batch6.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
 )
 import jax.numpy as jnp

--- a/jax2onnx/plugins/jax/numpy/compress.py
+++ b/jax2onnx/plugins/jax/numpy/compress.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+    Tracer,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -90,11 +94,11 @@ class JnpCompressPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.ShapedArray,
+        a: ShapedArray,
         *,
         axis: int,
         cond: tuple[bool, ...],
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         rank = len(a.shape)
         axis_norm = _canonical_axis(int(axis), rank)
         axis_dim = a.shape[axis_norm]
@@ -104,9 +108,9 @@ class JnpCompressPlugin(PrimitiveLeafPlugin):
             )
         out_shape = list(a.shape)
         out_shape[axis_norm] = _compress_len(cond, int(axis_dim))
-        return core.ShapedArray(tuple(out_shape), a.dtype)
+        return ShapedArray(tuple(out_shape), a.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (a_var,) = eqn.invars
         (out_var,) = eqn.outvars
 
@@ -182,7 +186,7 @@ class JnpCompressPlugin(PrimitiveLeafPlugin):
                         size=size,
                         fill_value=fill_value,
                     )
-                if isinstance(fill_value, core.Tracer):
+                if isinstance(fill_value, Tracer):
                     return orig_impl(
                         condition,
                         a,
@@ -211,7 +215,7 @@ class JnpCompressPlugin(PrimitiveLeafPlugin):
                         size=size,
                         fill_value=fill_value,
                     )
-                if isinstance(condition, core.Tracer):
+                if isinstance(condition, Tracer):
                     return orig_impl(
                         condition,
                         a,

--- a/jax2onnx/plugins/jax/numpy/compress.py
+++ b/jax2onnx/plugins/jax/numpy/compress.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
     Tracer,

--- a/jax2onnx/plugins/jax/numpy/concatenate.py
+++ b/jax2onnx/plugins/jax/numpy/concatenate.py
@@ -6,12 +6,16 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import numpy_dtype_to_ir
@@ -186,10 +190,10 @@ class JnpConcatenatePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        *arrays: core.AbstractValue,
+        *arrays: AbstractValue,
         dimension: int = 0,
         axis: int | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if not arrays:
             raise ValueError("concatenate requires at least one operand")
         if axis is not None:
@@ -219,9 +223,9 @@ class JnpConcatenatePlugin(PrimitiveLeafPlugin):
         else:
             out_shape[norm_axis] = axis_sizes[0]
         out_dtype = _promote_dtype([np.dtype(a.dtype) for a in arrays])
-        return jax.core.ShapedArray(tuple(out_shape), out_dtype)
+        return ShapedArray(tuple(out_shape), out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         out_var = eqn.outvars[0]
         in_vars = list(eqn.invars)
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/concatenate.py
+++ b/jax2onnx/plugins/jax/numpy/concatenate.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/conj.py
+++ b/jax2onnx/plugins/jax/numpy/conj.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.interpreters import batching
 import onnx_ir as ir
 from numpy.typing import ArrayLike
 
@@ -80,7 +83,7 @@ class JnpConjPlugin(PrimitiveLeafPlugin):
     _FUNC_NAME: ClassVar[str] = "conj"
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 
@@ -175,7 +178,7 @@ register_jvp_via_jax_jvp(JnpConjPlugin._PRIM, _conj_impl)
 
 
 JnpConjPlugin._PRIM.def_abstract_eval(
-    lambda x: core.ShapedArray(getattr(x, "shape", ()), getattr(x, "dtype", None))
+    lambda x: ShapedArray(getattr(x, "shape", ()), getattr(x, "dtype", None))
 )
 
 

--- a/jax2onnx/plugins/jax/numpy/conj.py
+++ b/jax2onnx/plugins/jax/numpy/conj.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, ClassVar, Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
     batching,

--- a/jax2onnx/plugins/jax/numpy/copysign.py
+++ b/jax2onnx/plugins/jax/numpy/copysign.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/copysign.py
+++ b/jax2onnx/plugins/jax/numpy/copysign.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -32,9 +36,9 @@ _COPYSIGN_PRIM: Final = make_jnp_primitive("jax.numpy.copysign")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -45,7 +49,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -149,9 +153,9 @@ class JnpCopysignPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpCopysignPlugin._PRIM,
             JnpCopysignPlugin._FUNC_NAME,
@@ -159,7 +163,7 @@ class JnpCopysignPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/cos.py
+++ b/jax2onnx/plugins/jax/numpy/cos.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 from onnx_ir import TensorType
@@ -99,14 +103,14 @@ class JnpCosPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpCosPlugin._PRIM,
             JnpCosPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/cos.py
+++ b/jax2onnx/plugins/jax/numpy/cos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/cosh.py
+++ b/jax2onnx/plugins/jax/numpy/cosh.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -82,14 +86,14 @@ class JnpCoshPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpCoshPlugin._PRIM,
             JnpCoshPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/cosh.py
+++ b/jax2onnx/plugins/jax/numpy/cosh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/cumprod.py
+++ b/jax2onnx/plugins/jax/numpy/cumprod.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -95,11 +99,11 @@ class JnpCumProdPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axis: int | None = None,
         dtype: np.dtype[Any] | type | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         out_dtype = np.dtype(dtype) if dtype is not None else np.dtype(x.dtype)
         out_shape = tuple(x.shape)
         if axis is None:
@@ -108,9 +112,9 @@ class JnpCumProdPlugin(PrimitiveLeafPlugin):
                 out_shape = (size,)
             else:
                 out_shape = (None,)
-        return core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (operand_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/cumprod.py
+++ b/jax2onnx/plugins/jax/numpy/cumprod.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/cumsum.py
+++ b/jax2onnx/plugins/jax/numpy/cumsum.py
@@ -8,15 +8,20 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
-from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax.lax._index_utils import _const_i64
-from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
+from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
+from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
+from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 from jax2onnx.plugins.jax.numpy._common import make_jnp_primitive
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
@@ -123,18 +128,18 @@ class JnpCumSumPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: jax.core.AbstractValue,
+        x: AbstractValue,
         *,
         axis: int | None = None,
         reverse: bool = False,
         dtype: np.dtype[Any] | type | None = None,
         **_: Any,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         out_shape = x.shape
         out_dtype = np.dtype(dtype) if dtype is not None else x.dtype
-        return jax.core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (operand_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/cumsum.py
+++ b/jax2onnx/plugins/jax/numpy/cumsum.py
@@ -15,7 +15,7 @@ from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/diag.py
+++ b/jax2onnx/plugins/jax/numpy/diag.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/diag.py
+++ b/jax2onnx/plugins/jax/numpy/diag.py
@@ -6,8 +6,12 @@ from collections.abc import Callable
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -40,10 +44,10 @@ def is_static_int_shape(shape: tuple[Any, ...]) -> bool:
 def abstract_eval_via_orig_diag(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
+    x: AbstractValue,
     *,
     k: int,
-) -> core.ShapedArray:
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
     x_spec = jax.ShapeDtypeStruct(x_shape, x_dtype)
@@ -51,7 +55,7 @@ def abstract_eval_via_orig_diag(
     out = jax.eval_shape(lambda a: orig(a, k=k), x_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _diag_extract_indices(rows: int, cols: int, k: int) -> NDArray[np.int64]:
@@ -190,7 +194,7 @@ class JnpDiagPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, *, k: int = 0) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, *, k: int = 0) -> ShapedArray:
         return abstract_eval_via_orig_diag(
             JnpDiagPlugin._PRIM,
             JnpDiagPlugin._FUNC_NAME,
@@ -198,7 +202,7 @@ class JnpDiagPlugin(PrimitiveLeafPlugin):
             k=int(k),
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/diagonal.py
+++ b/jax2onnx/plugins/jax/numpy/diagonal.py
@@ -6,8 +6,12 @@ from collections.abc import Callable
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -38,12 +42,12 @@ def _normalize_axis(axis: int, rank: int) -> int:
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
+    x: AbstractValue,
     *,
     offset: int,
     axis1: int,
     axis2: int,
-) -> core.ShapedArray:
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
     x_spec = jax.ShapeDtypeStruct(x_shape, x_dtype)
@@ -54,7 +58,7 @@ def _abstract_eval_via_orig(
     )
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 @register_primitive(
@@ -103,12 +107,12 @@ class JnpDiagonalPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         offset: int = 0,
         axis1: int = 0,
         axis2: int = 1,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(
             JnpDiagonalPlugin._PRIM,
             JnpDiagonalPlugin._FUNC_NAME,
@@ -118,7 +122,7 @@ class JnpDiagonalPlugin(PrimitiveLeafPlugin):
             axis2=int(axis2),
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/diagonal.py
+++ b/jax2onnx/plugins/jax/numpy/diagonal.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/digitize.py
+++ b/jax2onnx/plugins/jax/numpy/digitize.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -310,18 +314,18 @@ class JnpDigitizePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        bins: core.AbstractValue,
+        x: AbstractValue,
+        bins: AbstractValue,
         *,
         right: bool = False,
         method: str = "scan",
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del right, method
         if len(tuple(getattr(bins, "shape", ()))) != 1:
             raise TypeError("jnp.digitize lowering requires 1-D bins")
-        return core.ShapedArray(tuple(getattr(x, "shape", ())), _result_dtype())
+        return ShapedArray(tuple(getattr(x, "shape", ())), _result_dtype())
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, bins_var = eqn.invars
         (out_var,) = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/digitize.py
+++ b/jax2onnx/plugins/jax/numpy/digitize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/divide.py
+++ b/jax2onnx/plugins/jax/numpy/divide.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/divide.py
+++ b/jax2onnx/plugins/jax/numpy/divide.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -33,9 +37,9 @@ _DIVIDE_PRIM: Final = make_jnp_primitive("jax.numpy.divide")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -46,7 +50,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -131,9 +135,9 @@ class JnpDividePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpDividePlugin._PRIM,
             JnpDividePlugin._FUNC_NAME,
@@ -141,7 +145,7 @@ class JnpDividePlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/dot.py
+++ b/jax2onnx/plugins/jax/numpy/dot.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import onnx_ir as ir
 from numpy.typing import ArrayLike
@@ -90,13 +94,13 @@ class JnpDotPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
-        b: core.AbstractValue,
+        a: AbstractValue,
+        b: AbstractValue,
         *,
         precision: Any = None,
         preferred_element_type: Any = None,
         out_sharding: Any = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         shape, dtype = _dot_shape(
             a.shape,
             b.shape,
@@ -105,9 +109,9 @@ class JnpDotPlugin(PrimitiveLeafPlugin):
             preferred_element_type=preferred_element_type,
             out_sharding=out_sharding,
         )
-        return core.ShapedArray(shape, dtype)
+        return ShapedArray(shape, dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         a_var, b_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/dot.py
+++ b/jax2onnx/plugins/jax/numpy/dot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/einsum.py
+++ b/jax2onnx/plugins/jax/numpy/einsum.py
@@ -9,7 +9,11 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 from numpy.typing import ArrayLike
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -26,7 +30,7 @@ _JNP_EINSUM_ORIG: Final = jnp.einsum
 
 
 def _einsum_shape(
-    avals: Sequence[core.AbstractValue], equation: str
+    avals: Sequence[AbstractValue], equation: str
 ) -> tuple[tuple[Any, ...], np.dtype[Any]]:
     equation = _normalize_equation(equation)
     specs = [jax.ShapeDtypeStruct(a.shape, a.dtype) for a in avals]
@@ -308,19 +312,19 @@ class JnpEinsumPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        *avals: core.AbstractValue,
+        *avals: AbstractValue,
         equation: str,
         precision: Any | None = None,
         optimize: Any | None = None,
         preferred_element_type: Any | None = None,
         _dot_general: Any | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del _dot_general
         equation = _normalize_equation(equation)
         shape, dtype = _einsum_shape(avals, equation)
-        return core.ShapedArray(shape, dtype)
+        return ShapedArray(shape, dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         equation = _normalize_equation(params["equation"])
 

--- a/jax2onnx/plugins/jax/numpy/einsum.py
+++ b/jax2onnx/plugins/jax/numpy/einsum.py
@@ -13,6 +13,7 @@ from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,
+    batching,
 )
 from numpy.typing import ArrayLike
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -603,4 +604,4 @@ def _einsum_batch_rule(
     return result, 0
 
 
-jax.interpreters.batching.primitive_batchers[JnpEinsumPlugin._PRIM] = _einsum_batch_rule
+batching.primitive_batchers[JnpEinsumPlugin._PRIM] = _einsum_batch_rule

--- a/jax2onnx/plugins/jax/numpy/einsum.py
+++ b/jax2onnx/plugins/jax/numpy/einsum.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/equal.py
+++ b/jax2onnx/plugins/jax/numpy/equal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/equal.py
+++ b/jax2onnx/plugins/jax/numpy/equal.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -79,11 +83,11 @@ class JnpEqualPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
-        return core.ShapedArray(out_shape, np.dtype(np.bool_))
+        return ShapedArray(out_shape, np.dtype(np.bool_))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/exp.py
+++ b/jax2onnx/plugins/jax/numpy/exp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/exp.py
+++ b/jax2onnx/plugins/jax/numpy/exp.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -80,12 +84,12 @@ class JnpExpPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpExpPlugin._PRIM, JnpExpPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/exp2.py
+++ b/jax2onnx/plugins/jax/numpy/exp2.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -75,12 +79,12 @@ class JnpExp2Plugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpExp2Plugin._PRIM, JnpExp2Plugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (y_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/exp2.py
+++ b/jax2onnx/plugins/jax/numpy/exp2.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/expm1.py
+++ b/jax2onnx/plugins/jax/numpy/expm1.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -78,12 +82,12 @@ class JnpExpm1Plugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpExpm1Plugin._PRIM, JnpExpm1Plugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (y_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/expm1.py
+++ b/jax2onnx/plugins/jax/numpy/expm1.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/eye.py
+++ b/jax2onnx/plugins/jax/numpy/eye.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
 )

--- a/jax2onnx/plugins/jax/numpy/eye.py
+++ b/jax2onnx/plugins/jax/numpy/eye.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -76,13 +79,13 @@ class JnpEyePlugin(PrimitiveLeafPlugin):
         m: int | None = None,
         k: int = 0,
         dtype: np.dtype[Any] | type | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del k
         n_i, m_i = _normalize_dims(n, m)
         out_dtype = np.dtype(jnp.float32 if dtype is None else dtype)
-        return core.ShapedArray((n_i, m_i), out_dtype)
+        return ShapedArray((n_i, m_i), out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})
 

--- a/jax2onnx/plugins/jax/numpy/fabs.py
+++ b/jax2onnx/plugins/jax/numpy/fabs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/fabs.py
+++ b/jax2onnx/plugins/jax/numpy/fabs.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -80,12 +84,12 @@ class JnpFabsPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpFabsPlugin._PRIM, JnpFabsPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/fft.py
+++ b/jax2onnx/plugins/jax/numpy/fft.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.jax.lax.fft import FFTPlugin as _LaxFFTPlugin
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.converter.typing_support import LoweringContextProtocol

--- a/jax2onnx/plugins/jax/numpy/fft.py
+++ b/jax2onnx/plugins/jax/numpy/fft.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Final
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.jax.lax.fft import FFTPlugin as _LaxFFTPlugin
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -28,7 +28,7 @@ class _JnpFFTMetadata(PrimitiveLeafPlugin):
         return []
 
     def lower(
-        self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn
+        self, ctx: LoweringContextProtocol, eqn: JaxprEqn
     ) -> None:  # pragma: no cover - delegated lowering
         _LAX_FFT_PLUGIN.lower(ctx, eqn)
 

--- a/jax2onnx/plugins/jax/numpy/floor.py
+++ b/jax2onnx/plugins/jax/numpy/floor.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -84,14 +88,14 @@ class JnpFloorPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpFloorPlugin._PRIM,
             JnpFloorPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/floor.py
+++ b/jax2onnx/plugins/jax/numpy/floor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/floor_divide.py
+++ b/jax2onnx/plugins/jax/numpy/floor_divide.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -32,9 +36,9 @@ _FLOOR_DIVIDE_PRIM: Final = make_jnp_primitive("jax.numpy.floor_divide")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -45,7 +49,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -140,9 +144,9 @@ class JnpFloorDividePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpFloorDividePlugin._PRIM,
             JnpFloorDividePlugin._FUNC_NAME,
@@ -150,7 +154,7 @@ class JnpFloorDividePlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/floor_divide.py
+++ b/jax2onnx/plugins/jax/numpy/floor_divide.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/fmod.py
+++ b/jax2onnx/plugins/jax/numpy/fmod.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/fmod.py
+++ b/jax2onnx/plugins/jax/numpy/fmod.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -31,9 +35,9 @@ _FMOD_PRIM: Final = make_jnp_primitive("jax.numpy.fmod")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -44,7 +48,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -126,9 +130,9 @@ class JnpFmodPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpFmodPlugin._PRIM,
             JnpFmodPlugin._FUNC_NAME,
@@ -136,7 +140,7 @@ class JnpFmodPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/frexp.py
+++ b/jax2onnx/plugins/jax/numpy/frexp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/frexp.py
+++ b/jax2onnx/plugins/jax/numpy/frexp.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -31,8 +35,8 @@ BatchDim: TypeAlias = int | None
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-) -> tuple[core.ShapedArray, core.ShapedArray]:
+    x: AbstractValue,
+) -> tuple[ShapedArray, ShapedArray]:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
     x_spec = jax.ShapeDtypeStruct(x_shape, x_dtype)
@@ -43,8 +47,8 @@ def _abstract_eval_via_orig(
     mantissa_dtype = np.dtype(getattr(mantissa, "dtype", np.float32))
     exponent_dtype = np.dtype(getattr(exponent, "dtype", np.int32))
     return (
-        core.ShapedArray(mantissa_shape, mantissa_dtype),
-        core.ShapedArray(exponent_shape, exponent_dtype),
+        ShapedArray(mantissa_shape, mantissa_dtype),
+        ShapedArray(exponent_shape, exponent_dtype),
     )
 
 
@@ -165,14 +169,14 @@ class JnpFrexpPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> tuple[core.ShapedArray, ...]:
+    def abstract_eval(x: AbstractValue) -> tuple[ShapedArray, ...]:
         return _abstract_eval_via_orig(
             JnpFrexpPlugin._PRIM,
             JnpFrexpPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         mantissa_var, exponent_var = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/full.py
+++ b/jax2onnx/plugins/jax/numpy/full.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/full.py
+++ b/jax2onnx/plugins/jax/numpy/full.py
@@ -6,8 +6,12 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -85,14 +89,14 @@ class JnpFullPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        fill_value: core.AbstractValue,
+        fill_value: AbstractValue,
         *,
         shape: tuple[int, ...],
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         dims = _normalize_shape(shape)
-        return core.ShapedArray(dims, fill_value.dtype)
+        return ShapedArray(dims, fill_value.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (fill_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/greater.py
+++ b/jax2onnx/plugins/jax/numpy/greater.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/greater.py
+++ b/jax2onnx/plugins/jax/numpy/greater.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -85,11 +89,11 @@ class JnpGreaterPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
-        return core.ShapedArray(out_shape, np.dtype(np.bool_))
+        return ShapedArray(out_shape, np.dtype(np.bool_))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/greater_equal.py
+++ b/jax2onnx/plugins/jax/numpy/greater_equal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/greater_equal.py
+++ b/jax2onnx/plugins/jax/numpy/greater_equal.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -85,11 +89,11 @@ class JnpGreaterEqualPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
-        return core.ShapedArray(out_shape, np.dtype(np.bool_))
+        return ShapedArray(out_shape, np.dtype(np.bool_))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/histogram.py
+++ b/jax2onnx/plugins/jax/numpy/histogram.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Sequence, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/histogram.py
+++ b/jax2onnx/plugins/jax/numpy/histogram.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Sequence, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -180,9 +184,9 @@ def _unsupported_params(
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    a: core.AbstractValue,
-    bins: core.AbstractValue,
-) -> tuple[core.ShapedArray, core.ShapedArray]:
+    a: AbstractValue,
+    bins: AbstractValue,
+) -> tuple[ShapedArray, ShapedArray]:
     a_shape = tuple(getattr(a, "shape", ()))
     bins_shape = tuple(getattr(bins, "shape", ()))
     if len(bins_shape) != 1:
@@ -199,11 +203,11 @@ def _abstract_eval_via_orig(
     orig = get_orig_impl(prim, func_name)
     hist, edges = jax.eval_shape(lambda x, b: orig(x, bins=b), a_spec, bins_spec)
     return (
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(hist, "shape", ())),
             np.dtype(getattr(hist, "dtype", np.float32)),
         ),
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(edges, "shape", ())),
             np.dtype(getattr(edges, "dtype", np.float32)),
         ),
@@ -291,11 +295,11 @@ class JnpHistogramPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
-        bins: core.AbstractValue,
+        a: AbstractValue,
+        bins: AbstractValue,
         *,
         density: bool | None = None,
-    ) -> tuple[core.ShapedArray, ...]:
+    ) -> tuple[ShapedArray, ...]:
         if density not in (None, False):
             raise NotImplementedError(
                 "jnp.histogram with density=True is not supported for ONNX export"
@@ -307,7 +311,7 @@ class JnpHistogramPlugin(PrimitiveLeafPlugin):
             bins,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         a_var, bins_var = eqn.invars
         hist_var, edges_var = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/histogram2d.py
+++ b/jax2onnx/plugins/jax/numpy/histogram2d.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Sequence, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/histogram2d.py
+++ b/jax2onnx/plugins/jax/numpy/histogram2d.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Sequence, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -80,11 +84,11 @@ def _validate_edges_shape(shape: tuple[object, ...], *, axis_name: str) -> int:
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-    x_edges: core.AbstractValue,
-    y_edges: core.AbstractValue,
-) -> tuple[core.ShapedArray, core.ShapedArray, core.ShapedArray]:
+    x: AbstractValue,
+    y: AbstractValue,
+    x_edges: AbstractValue,
+    y_edges: AbstractValue,
+) -> tuple[ShapedArray, ShapedArray, ShapedArray]:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_edges_shape = tuple(getattr(x_edges, "shape", ()))
@@ -117,15 +121,15 @@ def _abstract_eval_via_orig(
         y_edges_spec,
     )
     return (
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(hist, "shape", ())),
             np.dtype(getattr(hist, "dtype", np.int32)),
         ),
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(x_edges_out, "shape", ())),
             np.dtype(getattr(x_edges_out, "dtype", np.float32)),
         ),
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(y_edges_out, "shape", ())),
             np.dtype(getattr(y_edges_out, "dtype", np.float32)),
         ),
@@ -329,13 +333,13 @@ class JnpHistogram2dPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-        x_edges: core.AbstractValue,
-        y_edges: core.AbstractValue,
+        x: AbstractValue,
+        y: AbstractValue,
+        x_edges: AbstractValue,
+        y_edges: AbstractValue,
         *,
         density: bool | None = None,
-    ) -> tuple[core.ShapedArray, ...]:
+    ) -> tuple[ShapedArray, ...]:
         if density not in (None, False):
             raise NotImplementedError(
                 "jnp.histogram2d with density=True is not supported for ONNX export"
@@ -349,7 +353,7 @@ class JnpHistogram2dPlugin(PrimitiveLeafPlugin):
             y_edges,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var, x_edges_var, y_edges_var = eqn.invars
         hist_var, x_edges_out_var, y_edges_out_var = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/histogramdd.py
+++ b/jax2onnx/plugins/jax/numpy/histogramdd.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Sequence, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -74,10 +78,10 @@ def _validate_sample_shape(shape: tuple[object, ...]) -> int:
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    sample: core.AbstractValue,
-    x_edges: core.AbstractValue,
-    y_edges: core.AbstractValue,
-) -> tuple[core.ShapedArray, core.ShapedArray, core.ShapedArray]:
+    sample: AbstractValue,
+    x_edges: AbstractValue,
+    y_edges: AbstractValue,
+) -> tuple[ShapedArray, ShapedArray, ShapedArray]:
     sample_shape = tuple(getattr(sample, "shape", ()))
     x_edges_shape = tuple(getattr(x_edges, "shape", ()))
     y_edges_shape = tuple(getattr(y_edges, "shape", ()))
@@ -108,15 +112,15 @@ def _abstract_eval_via_orig(
         y_edges_spec,
     )
     return (
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(hist, "shape", ())),
             np.dtype(getattr(hist, "dtype", np.int32)),
         ),
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(edges[0], "shape", ())),
             np.dtype(getattr(edges[0], "dtype", np.float32)),
         ),
-        core.ShapedArray(
+        ShapedArray(
             tuple(getattr(edges[1], "shape", ())),
             np.dtype(getattr(edges[1], "dtype", np.float32)),
         ),
@@ -253,12 +257,12 @@ class JnpHistogramddPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        sample: core.AbstractValue,
-        x_edges: core.AbstractValue,
-        y_edges: core.AbstractValue,
+        sample: AbstractValue,
+        x_edges: AbstractValue,
+        y_edges: AbstractValue,
         *,
         density: bool | None = None,
-    ) -> tuple[core.ShapedArray, ...]:
+    ) -> tuple[ShapedArray, ...]:
         if density not in (None, False):
             raise NotImplementedError(
                 "jnp.histogramdd with density=True is not supported for ONNX export"
@@ -271,7 +275,7 @@ class JnpHistogramddPlugin(PrimitiveLeafPlugin):
             y_edges,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         sample_var, x_edges_var, y_edges_var = eqn.invars
         hist_var, x_edges_out_var, y_edges_out_var = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/histogramdd.py
+++ b/jax2onnx/plugins/jax/numpy/histogramdd.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, Sequence, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/interp.py
+++ b/jax2onnx/plugins/jax/numpy/interp.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -166,10 +170,10 @@ def _binary_float_op(
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    xp: core.AbstractValue,
-    fp: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    xp: AbstractValue,
+    fp: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     xp_shape = tuple(getattr(xp, "shape", ()))
     fp_shape = tuple(getattr(fp, "shape", ()))
@@ -192,7 +196,7 @@ def _abstract_eval_via_orig(
     out_dtype = np.dtype(getattr(out, "dtype", np.float32))
     if np.issubdtype(out_dtype, np.complexfloating):
         raise TypeError("jnp.interp lowering does not support complex fp values")
-    return core.ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
+    return ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
 
 
 @register_primitive(
@@ -282,10 +286,10 @@ class JnpInterpPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        xp: core.AbstractValue,
-        fp: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        xp: AbstractValue,
+        fp: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(
             JnpInterpPlugin._PRIM,
             JnpInterpPlugin._FUNC_NAME,
@@ -294,7 +298,7 @@ class JnpInterpPlugin(PrimitiveLeafPlugin):
             fp,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, xp_var, fp_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/interp.py
+++ b/jax2onnx/plugins/jax/numpy/interp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/invert.py
+++ b/jax2onnx/plugins/jax/numpy/invert.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/invert.py
+++ b/jax2onnx/plugins/jax/numpy/invert.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -78,14 +82,14 @@ class JnpInvertPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpInvertPlugin._PRIM,
             JnpInvertPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/isfinite.py
+++ b/jax2onnx/plugins/jax/numpy/isfinite.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import ClassVar, Final
 
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -65,14 +69,14 @@ class JnpIsFinitePlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpIsFinitePlugin._PRIM,
             JnpIsFinitePlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/isfinite.py
+++ b/jax2onnx/plugins/jax/numpy/isfinite.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/ldexp.py
+++ b/jax2onnx/plugins/jax/numpy/ldexp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/ldexp.py
+++ b/jax2onnx/plugins/jax/numpy/ldexp.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -32,9 +36,9 @@ _LDEXP_PRIM: Final = make_jnp_primitive("jax.numpy.ldexp")
 def _abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    exp: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    exp: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     exp_shape = tuple(getattr(exp, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
@@ -45,7 +49,7 @@ def _abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, exp_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _cast_to_dtype(
@@ -122,9 +126,9 @@ class JnpLdexpPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        exp: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        exp: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_binary(
             JnpLdexpPlugin._PRIM,
             JnpLdexpPlugin._FUNC_NAME,
@@ -132,7 +136,7 @@ class JnpLdexpPlugin(PrimitiveLeafPlugin):
             exp,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, exp_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/left_shift.py
+++ b/jax2onnx/plugins/jax/numpy/left_shift.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/left_shift.py
+++ b/jax2onnx/plugins/jax/numpy/left_shift.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -38,9 +42,9 @@ _NP_SIGNED_TO_UNSIGNED: dict[np.dtype[Any], np.dtype[Any]] = {
 def abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.int32))
@@ -51,7 +55,7 @@ def abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def cast_to_dtype(
@@ -80,7 +84,7 @@ def cast_to_dtype(
 
 def lower_left_shift_core(
     ctx: LoweringContextProtocol,
-    eqn: core.JaxprEqn,
+    eqn: JaxprEqn,
     *,
     input_x_hint: str,
     input_y_hint: str,
@@ -234,9 +238,9 @@ class JnpLeftShiftPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return abstract_eval_via_orig_binary(
             JnpLeftShiftPlugin._PRIM,
             JnpLeftShiftPlugin._FUNC_NAME,
@@ -244,7 +248,7 @@ class JnpLeftShiftPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_left_shift_core(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/less.py
+++ b/jax2onnx/plugins/jax/numpy/less.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/less.py
+++ b/jax2onnx/plugins/jax/numpy/less.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -85,11 +89,11 @@ class JnpLessPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
-        return core.ShapedArray(out_shape, np.dtype(np.bool_))
+        return ShapedArray(out_shape, np.dtype(np.bool_))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/less_equal.py
+++ b/jax2onnx/plugins/jax/numpy/less_equal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/less_equal.py
+++ b/jax2onnx/plugins/jax/numpy/less_equal.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -85,11 +89,11 @@ class JnpLessEqualPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
-        return core.ShapedArray(out_shape, np.dtype(np.bool_))
+        return ShapedArray(out_shape, np.dtype(np.bool_))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/linalg_det.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_det.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/linalg_det.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_det.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -73,14 +77,14 @@ class JnpLinalgDetPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         storage_slot = f"__orig_impl__{JnpLinalgDetPlugin._FUNC_NAME}"
         orig = getattr(_LINALG_DET_PRIM, storage_slot, jnp.linalg.det)
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         result = jax.eval_shape(lambda arr: orig(arr), spec)
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/linalg_inv.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_inv.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/linalg_inv.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_inv.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -195,7 +199,7 @@ def _concat(
     return result
 
 
-def _abstract_eval_via_orig(x: core.AbstractValue) -> core.ShapedArray:
+def _abstract_eval_via_orig(x: AbstractValue) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype = np.dtype(getattr(x, "dtype", np.float32))
     if np.issubdtype(x_dtype, np.complexfloating):
@@ -207,7 +211,7 @@ def _abstract_eval_via_orig(x: core.AbstractValue) -> core.ShapedArray:
     out_dtype = np.dtype(getattr(out, "dtype", np.float32))
     if np.issubdtype(out_dtype, np.complexfloating):
         raise TypeError("jnp.linalg.inv lowering does not support complex outputs")
-    return core.ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
+    return ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
 
 
 @register_primitive(
@@ -293,10 +297,10 @@ class JnpLinalgInvPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return _abstract_eval_via_orig(x)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/linalg_norm.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_norm.py
@@ -6,8 +6,12 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import onnx_ir as ir
 import numpy as np
@@ -122,12 +126,12 @@ class JnpLinalgNormPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...],
         ord_value: int,
         keepdims: bool,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         storage_slot = f"__orig_impl__{JnpLinalgNormPlugin._FUNC_NAME}"
         orig = getattr(_LINALG_NORM_PRIM, storage_slot, jnp.linalg.norm)
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
@@ -138,9 +142,9 @@ class JnpLinalgNormPlugin(PrimitiveLeafPlugin):
             lambda arr: orig(arr, ord=ord_arg, axis=axis_arg, keepdims=keepdims),
             spec,
         )
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/linalg_norm.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_norm.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/linalg_solve.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_solve.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/linalg_solve.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_solve.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -33,9 +37,9 @@ _JAX_LINALG_SOLVE_ORIG: Final = jnp.linalg.solve
 
 
 def _abstract_eval_via_orig(
-    a: core.AbstractValue,
-    b: core.AbstractValue,
-) -> core.ShapedArray:
+    a: AbstractValue,
+    b: AbstractValue,
+) -> ShapedArray:
     a_shape = tuple(getattr(a, "shape", ()))
     b_shape = tuple(getattr(b, "shape", ()))
     a_dtype = np.dtype(getattr(a, "dtype", np.float32))
@@ -54,7 +58,7 @@ def _abstract_eval_via_orig(
     out_dtype = np.dtype(getattr(out, "dtype", np.float32))
     if np.issubdtype(out_dtype, np.complexfloating):
         raise TypeError("jnp.linalg.solve lowering does not support complex outputs")
-    return core.ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
+    return ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
 
 
 def _cast_to_output_dtype(
@@ -325,12 +329,12 @@ class JnpLinalgSolvePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
-        b: core.AbstractValue,
-    ) -> core.ShapedArray:
+        a: AbstractValue,
+        b: AbstractValue,
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(a, b)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         a_var, b_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/linalg_tensorinv.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_tensorinv.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -92,10 +96,10 @@ def _normalise_shapes(
 
 
 def _abstract_eval_via_orig(
-    x: core.AbstractValue,
+    x: AbstractValue,
     *,
     ind: int,
-) -> core.ShapedArray:
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype = np.dtype(getattr(x, "dtype", np.float32))
     if np.issubdtype(x_dtype, np.complexfloating):
@@ -110,7 +114,7 @@ def _abstract_eval_via_orig(
         raise TypeError(
             "jnp.linalg.tensorinv lowering does not support complex outputs"
         )
-    return core.ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
+    return ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
 
 
 def _invert_1x1(
@@ -392,13 +396,13 @@ class JnpLinalgTensorInvPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         ind: int = 2,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(x, ind=int(ind))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/linalg_tensorinv.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_tensorinv.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/linalg_tensorsolve.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_tensorsolve.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/linalg_tensorsolve.py
+++ b/jax2onnx/plugins/jax/numpy/linalg_tensorsolve.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -72,11 +76,11 @@ def _reshape(
 
 
 def _abstract_eval_via_orig(
-    a: core.AbstractValue,
-    b: core.AbstractValue,
+    a: AbstractValue,
+    b: AbstractValue,
     *,
     axes: tuple[int, ...] | None,
-) -> core.ShapedArray:
+) -> ShapedArray:
     a_shape = tuple(getattr(a, "shape", ()))
     b_shape = tuple(getattr(b, "shape", ()))
     a_dtype = np.dtype(getattr(a, "dtype", np.float32))
@@ -98,7 +102,7 @@ def _abstract_eval_via_orig(
         raise TypeError(
             "jnp.linalg.tensorsolve lowering does not support complex outputs"
         )
-    return core.ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
+    return ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
 
 
 def _normalise_shapes(
@@ -203,14 +207,14 @@ class JnpLinalgTensorSolvePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
-        b: core.AbstractValue,
+        a: AbstractValue,
+        b: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(a, b, axes=axes)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         a_var, b_var = eqn.invars
         (out_var,) = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/linspace.py
+++ b/jax2onnx/plugins/jax/numpy/linspace.py
@@ -9,8 +9,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -37,8 +41,8 @@ def _normalize_dtype(result_dtype: np.dtype[Any], enable_double: bool) -> np.dty
 
 
 def _infer_result_dtype(
-    start_aval: core.AbstractValue,
-    stop_aval: core.AbstractValue,
+    start_aval: AbstractValue,
+    stop_aval: AbstractValue,
     dtype_param: np.dtype[Any] | type | None,
     enable_double: bool,
 ) -> np.dtype[Any]:
@@ -298,15 +302,15 @@ class JnpLinspacePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        start: core.AbstractValue,
-        stop: core.AbstractValue,
+        start: AbstractValue,
+        stop: AbstractValue,
         *,
         num: int = 50,
         endpoint: bool = True,
         retstep: bool = False,
         dtype: np.dtype[Any] | type | None = None,
         axis: int = 0,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if retstep:
             raise NotImplementedError("jnp.linspace with retstep=True is not supported")
         if axis != 0:
@@ -316,9 +320,9 @@ class JnpLinspacePlugin(PrimitiveLeafPlugin):
             raise ValueError("num must be non-negative")
         enable_x64 = bool(jax.config.jax_enable_x64)
         result_dtype = _infer_result_dtype(start, stop, dtype, enable_x64)
-        return core.ShapedArray((num_int,), result_dtype)
+        return ShapedArray((num_int,), result_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         num = int(params.get("num", 50))
         if num < 0:

--- a/jax2onnx/plugins/jax/numpy/linspace.py
+++ b/jax2onnx/plugins/jax/numpy/linspace.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/log.py
+++ b/jax2onnx/plugins/jax/numpy/log.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/log.py
+++ b/jax2onnx/plugins/jax/numpy/log.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -90,12 +94,12 @@ class JnpLogPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpLogPlugin._PRIM, JnpLogPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/matmul.py
+++ b/jax2onnx/plugins/jax/numpy/matmul.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-import jax.extend.core as jax_core_ext
 import jax.numpy as jnp
 import onnx_ir as ir
 from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,
+    Var,
     batching,
 )
 import numpy as np
@@ -253,9 +253,9 @@ class JnpMatmulPlugin(PrimitiveLeafPlugin):
     def _maybe_lower_complex(
         self,
         ctx: LoweringContextProtocol,
-        a_var: jax_core_ext.Var,
-        b_var: jax_core_ext.Var,
-        out_var: jax_core_ext.Var,
+        a_var: Var,
+        b_var: Var,
+        out_var: Var,
         a_val: ir.Value,
         b_val: ir.Value,
         out_spec: ir.Value,

--- a/jax2onnx/plugins/jax/numpy/matmul.py
+++ b/jax2onnx/plugins/jax/numpy/matmul.py
@@ -8,8 +8,12 @@ import jax
 import jax.extend.core as jax_core_ext
 import jax.numpy as jnp
 import onnx_ir as ir
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import numpy as np
 from numpy.typing import ArrayLike
 
@@ -180,13 +184,13 @@ class JnpMatmulPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
-        b: core.AbstractValue,
+        a: AbstractValue,
+        b: AbstractValue,
         *,
         precision: Any | None = None,
         preferred_element_type: Any | None = None,
         out_sharding: Any | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         shape, dtype = _matmul_shape(
             a.shape,
             b.shape,
@@ -195,9 +199,9 @@ class JnpMatmulPlugin(PrimitiveLeafPlugin):
             preferred_element_type=preferred_element_type,
             out_sharding=out_sharding,
         )
-        return core.ShapedArray(shape, dtype)
+        return ShapedArray(shape, dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         a_var, b_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/matmul.py
+++ b/jax2onnx/plugins/jax/numpy/matmul.py
@@ -8,7 +8,7 @@ import jax
 import jax.extend.core as jax_core_ext
 import jax.numpy as jnp
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/max.py
+++ b/jax2onnx/plugins/jax/numpy/max.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/max.py
+++ b/jax2onnx/plugins/jax/numpy/max.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -87,12 +91,12 @@ class JnpMaxPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         keepdims: bool = False,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpMaxPlugin._PRIM,
             JnpMaxPlugin._FUNC_NAME,
@@ -102,7 +106,7 @@ class JnpMaxPlugin(PrimitiveLeafPlugin):
             keepdims=keepdims,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_reduction(ctx, eqn, op_type="ReduceMax", allow_dtype_param=False)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/maximum.py
+++ b/jax2onnx/plugins/jax/numpy/maximum.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final, cast
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/maximum.py
+++ b/jax2onnx/plugins/jax/numpy/maximum.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final, cast
 
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -55,12 +59,12 @@ class JnpMaximumPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
         out_dtype = np.promote_types(x.dtype, y.dtype)
-        return core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/mean.py
+++ b/jax2onnx/plugins/jax/numpy/mean.py
@@ -9,9 +9,13 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
-from jax.interpreters import batching
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -125,14 +129,14 @@ class JnpMeanPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: Sequence[int] | None = None,
         dtype: np.dtype[Any] | type | None = None,
         out: None = None,
         keepdims: bool = False,
         where: bool = True,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if out is not None:
             raise NotImplementedError(
                 "jnp.mean with 'out' is not supported in ONNX lowering"
@@ -177,9 +181,9 @@ class JnpMeanPlugin(PrimitiveLeafPlugin):
                     dim for i, dim in enumerate(x.shape) if i not in axes_tuple
                 )
 
-        return jax.core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         # Manual lowering to avoid potential issues in shared utils
         operand_var = eqn.invars[0]
         out_var = eqn.outvars[0]

--- a/jax2onnx/plugins/jax/numpy/mean.py
+++ b/jax2onnx/plugins/jax/numpy/mean.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/min.py
+++ b/jax2onnx/plugins/jax/numpy/min.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/min.py
+++ b/jax2onnx/plugins/jax/numpy/min.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence as _Seq
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -87,12 +91,12 @@ class JnpMinPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         keepdims: bool = False,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpMinPlugin._PRIM,
             JnpMinPlugin._FUNC_NAME,
@@ -102,7 +106,7 @@ class JnpMinPlugin(PrimitiveLeafPlugin):
             keepdims=keepdims,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_reduction(ctx, eqn, op_type="ReduceMin", allow_dtype_param=False)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/minimum.py
+++ b/jax2onnx/plugins/jax/numpy/minimum.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final, cast
 
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -55,12 +59,12 @@ class JnpMinimumPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         out_shape = tuple(jnp.broadcast_shapes(x.shape, y.shape))
         out_dtype = np.promote_types(x.dtype, y.dtype)
-        return core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lhs_var, rhs_var = eqn.invars
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/numpy/minimum.py
+++ b/jax2onnx/plugins/jax/numpy/minimum.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Final, cast
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/moveaxis.py
+++ b/jax2onnx/plugins/jax/numpy/moveaxis.py
@@ -6,8 +6,12 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 from numpy.typing import ArrayLike
 
@@ -103,14 +107,14 @@ class JnpMoveaxisPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
+        a: AbstractValue,
         *,
         permutation: tuple[int, ...],
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         out_shape = tuple(a.shape[i] for i in permutation)
-        return core.ShapedArray(out_shape, a.dtype)
+        return ShapedArray(out_shape, a.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (arr_var,) = eqn.invars
         (out_var,) = eqn.outvars
         permutation = tuple(int(p) for p in eqn.params.get("permutation", ()))

--- a/jax2onnx/plugins/jax/numpy/moveaxis.py
+++ b/jax2onnx/plugins/jax/numpy/moveaxis.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/nancumprod.py
+++ b/jax2onnx/plugins/jax/numpy/nancumprod.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -130,11 +134,11 @@ def _cast_to_dtype(
 
 
 def _abstract_eval_via_orig(
-    x: core.AbstractValue,
+    x: AbstractValue,
     *,
     axis: int | None,
     dtype: np.dtype[Any] | type | None,
-) -> core.ShapedArray:
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype = np.dtype(getattr(x, "dtype", np.float32))
     if np.issubdtype(x_dtype, np.complexfloating):
@@ -147,7 +151,7 @@ def _abstract_eval_via_orig(
     out_dtype = np.dtype(getattr(out, "dtype", np.float32))
     if np.issubdtype(out_dtype, np.complexfloating):
         raise TypeError("jnp.nancumprod lowering does not support complex outputs")
-    return core.ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
+    return ShapedArray(tuple(getattr(out, "shape", ())), out_dtype)
 
 
 @register_primitive(
@@ -243,14 +247,14 @@ class JnpNanCumProdPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axis: int | None = None,
         dtype: np.dtype[Any] | type | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(x, axis=axis, dtype=dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (operand_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/nancumprod.py
+++ b/jax2onnx/plugins/jax/numpy/nancumprod.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/ones.py
+++ b/jax2onnx/plugins/jax/numpy/ones.py
@@ -6,7 +6,10 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -71,11 +74,11 @@ class JnpOnesPlugin(PrimitiveLeafPlugin):
         *,
         shape: tuple[int, ...],
         dtype: np.dtype[Any] | type,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         dims = _normalize_shape(shape)
-        return core.ShapedArray(dims, np.dtype(dtype))
+        return ShapedArray(dims, np.dtype(dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})
 

--- a/jax2onnx/plugins/jax/numpy/ones.py
+++ b/jax2onnx/plugins/jax/numpy/ones.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
 )

--- a/jax2onnx/plugins/jax/numpy/outer.py
+++ b/jax2onnx/plugins/jax/numpy/outer.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 from typing import ClassVar, Final, TypeAlias
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -63,12 +67,12 @@ class JnpOuterPlugin(PrimitiveLeafPlugin):
     _FUNC_NAME: ClassVar[str] = "outer"
 
     @staticmethod
-    def abstract_eval(a: core.AbstractValue, b: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(a: AbstractValue, b: AbstractValue) -> ShapedArray:
         result_shape = tuple(a.shape) + tuple(b.shape)
         result_dtype = np.result_type(a.dtype, b.dtype)
-        return jax.core.ShapedArray(result_shape, result_dtype)
+        return ShapedArray(result_shape, result_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (a_var, b_var) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/outer.py
+++ b/jax2onnx/plugins/jax/numpy/outer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/pad.py
+++ b/jax2onnx/plugins/jax/numpy/pad.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/pad.py
+++ b/jax2onnx/plugins/jax/numpy/pad.py
@@ -6,8 +6,12 @@ from collections.abc import Callable, Sequence
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -91,11 +95,11 @@ def _normalize_constant_value(value: Any) -> Any:
 def _abstract_eval_via_orig_pad(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
+    x: AbstractValue,
     *,
     pad_width: PadWidth,
     constant_value: Any,
-) -> core.ShapedArray:
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
     x_spec = jax.ShapeDtypeStruct(x_shape, x_dtype)
@@ -106,7 +110,7 @@ def _abstract_eval_via_orig_pad(
     )
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 @register_primitive(
@@ -148,11 +152,11 @@ class JnpPadPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         pad_width: PadWidth,
         constant_value: Any,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return _abstract_eval_via_orig_pad(
             JnpPadPlugin._PRIM,
             JnpPadPlugin._FUNC_NAME,
@@ -161,7 +165,7 @@ class JnpPadPlugin(PrimitiveLeafPlugin):
             constant_value=constant_value,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/polyfit.py
+++ b/jax2onnx/plugins/jax/numpy/polyfit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/polyfit.py
+++ b/jax2onnx/plugins/jax/numpy/polyfit.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -61,14 +65,14 @@ def _normalise_linear_shapes(
 
 
 def _abstract_eval_via_orig(
-    x: core.AbstractValue,
-    y: core.AbstractValue,
+    x: AbstractValue,
+    y: AbstractValue,
     *,
     deg: int,
     rcond: float | None,
     full: bool,
     cov: bool | str,
-) -> core.ShapedArray:
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype = np.dtype(getattr(x, "dtype", np.float32))
@@ -90,7 +94,7 @@ def _abstract_eval_via_orig(
         jax.ShapeDtypeStruct(x_shape, x_dtype),
         jax.ShapeDtypeStruct(y_shape, y_dtype),
     )
-    return core.ShapedArray(
+    return ShapedArray(
         tuple(getattr(out, "shape", ())), getattr(out, "dtype", np.float32)
     )
 
@@ -180,14 +184,14 @@ class JnpPolyfitPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
+        x: AbstractValue,
+        y: AbstractValue,
         *,
         deg: int,
         rcond: float | None = None,
         full: bool = False,
         cov: bool | str = False,
-    ) -> core.AbstractValue:
+    ) -> AbstractValue:
         return _abstract_eval_via_orig(
             x,
             y,
@@ -197,7 +201,7 @@ class JnpPolyfitPlugin(PrimitiveLeafPlugin):
             cov=cov,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         x_var, y_var = eqn.invars
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})

--- a/jax2onnx/plugins/jax/numpy/pow.py
+++ b/jax2onnx/plugins/jax/numpy/pow.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/numpy/pow.py
+++ b/jax2onnx/plugins/jax/numpy/pow.py
@@ -6,11 +6,15 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
@@ -69,11 +73,11 @@ class _BaseJnpPow(PrimitiveLeafPlugin):
     _FUNC_NAME: ClassVar[str]
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue, y: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue, y: AbstractValue) -> ShapedArray:
         shape = _broadcast_shape(x.shape, y.shape)
-        return core.ShapedArray(shape, x.dtype)
+        return ShapedArray(shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_pow(ctx, eqn)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/prod.py
+++ b/jax2onnx/plugins/jax/numpy/prod.py
@@ -9,9 +9,14 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    ad,
+    batching,
+)
 import jax.numpy as jnp
-from jax.interpreters import ad, batching
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -150,7 +155,7 @@ class JnpProdPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: Sequence[int] | None = None,
         axes_is_tuple: bool = False,  # ignored, kept for signature symmetry
@@ -158,7 +163,7 @@ class JnpProdPlugin(PrimitiveLeafPlugin):
         keepdims: bool = False,
         initial: ArrayLike | None = None,
         where: bool = True,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if initial is not None:
             raise NotImplementedError(
                 "jnp.prod with 'initial' is not supported in ONNX lowering"
@@ -193,9 +198,9 @@ class JnpProdPlugin(PrimitiveLeafPlugin):
                     dim for i, dim in enumerate(x.shape) if i not in axes_tuple
                 )
 
-        return jax.core.ShapedArray(out_shape, out_dtype)
+        return ShapedArray(out_shape, out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_reduction(ctx, eqn, op_type="ReduceProd", allow_dtype_param=True)
 
     @classmethod

--- a/jax2onnx/plugins/jax/numpy/prod.py
+++ b/jax2onnx/plugins/jax/numpy/prod.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/reshape.py
+++ b/jax2onnx/plugins/jax/numpy/reshape.py
@@ -7,11 +7,15 @@ from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
 import jax.numpy as jnp
-from jax.interpreters import batching
 import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
@@ -318,14 +322,14 @@ class JnpReshapePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         new_sizes: Sequence[int | object] | int | object | None = None,
         dimensions: Sequence[int] | None = None,
         sharding: Any | None = None,
         newshape: Sequence[int | object] | int | object | None = None,
         order: str | None = "C",
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         new_sizes_tuple, dimensions_tuple, _ = _canonicalize_reshape_params(
             new_sizes=new_sizes,
             dimensions=dimensions,
@@ -344,7 +348,7 @@ class JnpReshapePlugin(PrimitiveLeafPlugin):
                 ),
                 spec,
             )
-            return core.ShapedArray(result.shape, result.dtype)
+            return ShapedArray(result.shape, result.dtype)
 
         storage_slot = f"__orig_impl___{JnpReshapePlugin._FUNC_NAME}"
         orig = getattr(JnpReshapePlugin._PRIM, storage_slot, jnp.reshape)
@@ -353,9 +357,9 @@ class JnpReshapePlugin(PrimitiveLeafPlugin):
         result = jax.eval_shape(
             lambda arr: orig(arr, new_sizes_tuple, order=order_arg), spec
         )
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         new_sizes_param = params.get("new_sizes")
         dimensions_param = params.get("dimensions")

--- a/jax2onnx/plugins/jax/numpy/reshape.py
+++ b/jax2onnx/plugins/jax/numpy/reshape.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/right_shift.py
+++ b/jax2onnx/plugins/jax/numpy/right_shift.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/right_shift.py
+++ b/jax2onnx/plugins/jax/numpy/right_shift.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -47,9 +51,9 @@ _SIGNED_INTEGER_DTYPES: frozenset[np.dtype[Any]] = frozenset(
 def abstract_eval_via_orig_binary(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-    y: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+    y: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     y_shape = tuple(getattr(y, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.int32))
@@ -60,7 +64,7 @@ def abstract_eval_via_orig_binary(
     out = jax.eval_shape(lambda a, b: orig(a, b), x_spec, y_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def cast_to_dtype(
@@ -258,7 +262,7 @@ def _lower_signed_arithmetic_right_shift(
 
 def lower_right_shift_core(
     ctx: LoweringContextProtocol,
-    eqn: core.JaxprEqn,
+    eqn: JaxprEqn,
     *,
     input_x_hint: str,
     input_y_hint: str,
@@ -399,9 +403,9 @@ class JnpRightShiftPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
-        y: core.AbstractValue,
-    ) -> core.ShapedArray:
+        x: AbstractValue,
+        y: AbstractValue,
+    ) -> ShapedArray:
         return abstract_eval_via_orig_binary(
             JnpRightShiftPlugin._PRIM,
             JnpRightShiftPlugin._FUNC_NAME,
@@ -409,7 +413,7 @@ class JnpRightShiftPlugin(PrimitiveLeafPlugin):
             y,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_right_shift_core(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/roots.py
+++ b/jax2onnx/plugins/jax/numpy/roots.py
@@ -6,7 +6,12 @@ from collections.abc import Sequence
 from typing import Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    Var,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -618,7 +623,7 @@ def _quadratic_roots(
 
 def _bind_packed_output(
     ctx: LoweringContextProtocol,
-    out_var: core.Var,
+    out_var: Var,
     value: ir.Value,
     *,
     base_dtype: ir.DataType,
@@ -637,10 +642,10 @@ def _bind_packed_output(
 
 
 def _abstract_eval_via_orig(
-    p: core.AbstractValue,
+    p: AbstractValue,
     *,
     strip_zeros: bool,
-) -> core.ShapedArray:
+) -> ShapedArray:
     p_shape = tuple(getattr(p, "shape", ()))
     p_dtype = np.dtype(getattr(p, "dtype", np.float32))
     orig = get_orig_impl(_ROOTS_PRIM, "roots")
@@ -648,7 +653,7 @@ def _abstract_eval_via_orig(
         lambda value: orig(value, strip_zeros=strip_zeros),
         jax.ShapeDtypeStruct(p_shape, p_dtype),
     )
-    return core.ShapedArray(
+    return ShapedArray(
         tuple(getattr(out, "shape", ())), getattr(out, "dtype", np.complex64)
     )
 
@@ -735,13 +740,13 @@ class JnpRootsPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        p: core.AbstractValue,
+        p: AbstractValue,
         *,
         strip_zeros: bool = True,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return _abstract_eval_via_orig(p, strip_zeros=bool(strip_zeros))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (p_var,) = eqn.invars
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})

--- a/jax2onnx/plugins/jax/numpy/roots.py
+++ b/jax2onnx/plugins/jax/numpy/roots.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from typing import Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/searchsorted.py
+++ b/jax2onnx/plugins/jax/numpy/searchsorted.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -172,19 +176,19 @@ class JnpSearchSortedPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
-        v: core.AbstractValue,
+        a: AbstractValue,
+        v: AbstractValue,
         *,
         side: str = "left",
         method: str = "scan",
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del method
         _validate_side(side)
         if len(tuple(getattr(a, "shape", ()))) != 1:
             raise TypeError("jnp.searchsorted lowering requires 1-D sorted input 'a'")
-        return core.ShapedArray(tuple(getattr(v, "shape", ())), _result_dtype())
+        return ShapedArray(tuple(getattr(v, "shape", ())), _result_dtype())
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         a_var, v_var = eqn.invars
         (out_var,) = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/searchsorted.py
+++ b/jax2onnx/plugins/jax/numpy/searchsorted.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/select.py
+++ b/jax2onnx/plugins/jax/numpy/select.py
@@ -11,8 +11,13 @@ import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
-from jax import core
-from jax.interpreters import ad, batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    ad,
+    batching,
+)
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
@@ -119,8 +124,8 @@ class JnpSelectPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        *operands: core.AbstractValue, num_conds: int, num_choices: int
-    ) -> core.ShapedArray:
+        *operands: AbstractValue, num_conds: int, num_choices: int
+    ) -> ShapedArray:
         conds = operands[:num_conds]
         choices = operands[num_conds : num_conds + num_choices]
         default = operands[-1]
@@ -130,9 +135,9 @@ class JnpSelectPlugin(PrimitiveLeafPlugin):
             default.shape,
         )
         dtype = _promote_dtype(*(c.dtype for c in choices), default.dtype)
-        return core.ShapedArray(shape, dtype)
+        return ShapedArray(shape, dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         num_conds = int(params["num_conds"])
         num_choices = int(params["num_choices"])

--- a/jax2onnx/plugins/jax/numpy/select.py
+++ b/jax2onnx/plugins/jax/numpy/select.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-import jax.extend.core as jax_core_ext
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -15,6 +14,7 @@ from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,
+    Var,
     ad,
     batching,
 )
@@ -208,9 +208,7 @@ class JnpSelectPlugin(PrimitiveLeafPlugin):
         bind_value(out_var, final_val)
 
     @staticmethod
-    def _ensure_bool(
-        ctx: LoweringContextProtocol, val: ir.Value, var: jax_core_ext.Var
-    ) -> ir.Value:
+    def _ensure_bool(ctx: LoweringContextProtocol, val: ir.Value, var: Var) -> ir.Value:
         dtype = getattr(getattr(var, "aval", None), "dtype", np.bool_)
         if dtype == np.bool_:
             return val
@@ -234,7 +232,7 @@ class JnpSelectPlugin(PrimitiveLeafPlugin):
     def _ensure_dtype(
         ctx: LoweringContextProtocol,
         val: ir.Value,
-        var: jax_core_ext.Var,
+        var: Var,
         target_dtype: np.dtype[Any],
     ) -> ir.Value:
         dtype = getattr(getattr(var, "aval", None), "dtype", target_dtype)

--- a/jax2onnx/plugins/jax/numpy/select.py
+++ b/jax2onnx/plugins/jax/numpy/select.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/shape.py
+++ b/jax2onnx/plugins/jax/numpy/shape.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
 from jax import lax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/shape.py
+++ b/jax2onnx/plugins/jax/numpy/shape.py
@@ -8,8 +8,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax import core, lax
-from jax.interpreters import batching
+from jax import lax
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -23,7 +28,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 _SHAPE_PRIM: Final = make_jnp_primitive("jax.numpy.shape")
 
 
-def _shape_eval(x: jax.core.AbstractValue) -> Any:
+def _shape_eval(x: AbstractValue) -> Any:
     orig = getattr(_SHAPE_PRIM, "__orig_impl__shape", jnp.shape)
     result = jax.eval_shape(
         lambda arr: orig(arr), jax.ShapeDtypeStruct(x.shape, x.dtype)
@@ -75,17 +80,17 @@ class JnpShapePlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: jax.core.AbstractValue) -> jax.core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         result = _shape_eval(x)
         if isinstance(result, tuple):
             rank = len(result)
             if rank == 0:
-                return core.ShapedArray((0,), jnp.int32)
+                return ShapedArray((0,), jnp.int32)
             dtype = getattr(result[0], "dtype", jnp.int32)
-            return core.ShapedArray((rank,), dtype)
-        return core.ShapedArray(result.shape, result.dtype)
+            return ShapedArray((rank,), dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (arr_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/sign.py
+++ b/jax2onnx/plugins/jax/numpy/sign.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -80,14 +84,14 @@ class JnpSignPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpSignPlugin._PRIM,
             JnpSignPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/sign.py
+++ b/jax2onnx/plugins/jax/numpy/sign.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/sin.py
+++ b/jax2onnx/plugins/jax/numpy/sin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/sin.py
+++ b/jax2onnx/plugins/jax/numpy/sin.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -80,12 +84,12 @@ class JnpSinPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpSinPlugin._PRIM, JnpSinPlugin._FUNC_NAME, x
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/sinh.py
+++ b/jax2onnx/plugins/jax/numpy/sinh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/sinh.py
+++ b/jax2onnx/plugins/jax/numpy/sinh.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -82,14 +86,14 @@ class JnpSinhPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpSinhPlugin._PRIM,
             JnpSinhPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/size.py
+++ b/jax2onnx/plugins/jax/numpy/size.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/size.py
+++ b/jax2onnx/plugins/jax/numpy/size.py
@@ -6,8 +6,12 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -115,17 +119,17 @@ class JnpSizePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,  # kept for bind symmetry
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del x, axes, axes_is_tuple
         use_x64 = bool(jax.config.read("jax_enable_x64"))
         out_dtype = np.int64 if use_x64 else np.int32
-        return core.ShapedArray((), out_dtype)
+        return ShapedArray((), out_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})

--- a/jax2onnx/plugins/jax/numpy/sort.py
+++ b/jax2onnx/plugins/jax/numpy/sort.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
@@ -28,7 +32,7 @@ from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primiti
 _SORT_PRIM: Final = make_jnp_primitive("jax.numpy.sort")
 
 
-def _sort_eval(x: core.AbstractValue, axis: int = -1) -> jax.ShapeDtypeStruct:
+def _sort_eval(x: AbstractValue, axis: int = -1) -> jax.ShapeDtypeStruct:
     orig = getattr(_SORT_PRIM, "__orig_impl__sort", jnp.sort)
     spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
     result = jax.eval_shape(lambda arr: orig(arr, axis=axis), spec)
@@ -90,20 +94,20 @@ class JnpSortPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axis: int = -1,
         kind: str | None = None,
         order: Any | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if kind not in (None, "stable", "mergesort"):
             raise NotImplementedError("Only default/stable sorts supported")
         if order is not None:
             raise NotImplementedError("jnp.sort order parameter is not supported")
         result = _sort_eval(x, axis=axis)
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         axis = int(params.get("axis", -1))
         kind = params.get("kind", None)

--- a/jax2onnx/plugins/jax/numpy/sort.py
+++ b/jax2onnx/plugins/jax/numpy/sort.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, TypeAlias
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/spacing.py
+++ b/jax2onnx/plugins/jax/numpy/spacing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/spacing.py
+++ b/jax2onnx/plugins/jax/numpy/spacing.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -34,8 +38,8 @@ _SPACING_PRIM: Final = make_jnp_primitive("jax.numpy.spacing")
 def _abstract_eval_via_orig(
     prim: Any,
     func_name: str,
-    x: core.AbstractValue,
-) -> core.ShapedArray:
+    x: AbstractValue,
+) -> ShapedArray:
     x_shape = tuple(getattr(x, "shape", ()))
     x_dtype: np.dtype[Any] = np.dtype(getattr(x, "dtype", np.float32))
     x_spec = jax.ShapeDtypeStruct(x_shape, x_dtype)
@@ -43,7 +47,7 @@ def _abstract_eval_via_orig(
     out = jax.eval_shape(lambda value: orig(value), x_spec)
     out_shape = tuple(getattr(out, "shape", ()))
     out_dtype = np.dtype(getattr(out, "dtype", x_dtype))
-    return core.ShapedArray(out_shape, out_dtype)
+    return ShapedArray(out_shape, out_dtype)
 
 
 def _const(
@@ -165,14 +169,14 @@ class JnpSpacingPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return _abstract_eval_via_orig(
             JnpSpacingPlugin._PRIM,
             JnpSpacingPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/split.py
+++ b/jax2onnx/plugins/jax/numpy/split.py
@@ -9,8 +9,11 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -210,14 +213,14 @@ class JnpSplitPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.ShapedArray,
+        x: ShapedArray,
         *,
         sizes: Sequence[int] | None = None,
         indices_or_sections: (
             int | Sequence[int | np.integer] | np.ndarray | None
         ) = None,
         axis: int = 0,
-    ) -> tuple[core.ShapedArray, ...]:
+    ) -> tuple[ShapedArray, ...]:
         rank = len(x.shape)
         axis_norm = _normalize_axis(axis, rank)
         dim = x.shape[axis_norm]
@@ -237,10 +240,10 @@ class JnpSplitPlugin(PrimitiveLeafPlugin):
         for sz in sizes_tuple:
             shape = list(x.shape)
             shape[axis_norm] = sz
-            specs.append(core.ShapedArray(tuple(shape), x.dtype))
+            specs.append(ShapedArray(tuple(shape), x.dtype))
         return tuple(specs)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         axis_param = params.get("axis", 0)
         sizes_param = params.get("sizes")

--- a/jax2onnx/plugins/jax/numpy/split.py
+++ b/jax2onnx/plugins/jax/numpy/split.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
     batching,

--- a/jax2onnx/plugins/jax/numpy/sqrt.py
+++ b/jax2onnx/plugins/jax/numpy/sqrt.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -103,14 +107,14 @@ class JnpSqrtPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpSqrtPlugin._PRIM,
             JnpSqrtPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/sqrt.py
+++ b/jax2onnx/plugins/jax/numpy/sqrt.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/squeeze.py
+++ b/jax2onnx/plugins/jax/numpy/squeeze.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/squeeze.py
+++ b/jax2onnx/plugins/jax/numpy/squeeze.py
@@ -9,8 +9,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _ensure_value_metadata, _stamp_type_and_shape
@@ -203,12 +207,12 @@ class JnpSqueezePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         dimensions: Sequence[int] | None = None,
         axes: int | Sequence[int] | None = None,
         axis: int | Sequence[int] | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         dims = _resolve_dimensions(
             rank=len(x.shape),
             shape=tuple(x.shape),
@@ -220,9 +224,9 @@ class JnpSqueezePlugin(PrimitiveLeafPlugin):
         orig = getattr(JnpSqueezePlugin._PRIM, storage_slot, jnp.squeeze)
         spec = jax.ShapeDtypeStruct(x.shape, x.dtype)
         result = jax.eval_shape(lambda arr: orig(arr, axis=dims), spec)
-        return core.ShapedArray(result.shape, result.dtype)
+        return ShapedArray(result.shape, result.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         dimensions_param = params.get("dimensions")
         axes_param = params.get("axes")

--- a/jax2onnx/plugins/jax/numpy/stack.py
+++ b/jax2onnx/plugins/jax/numpy/stack.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Final, TypeAlias
 
 import jax
 from jax import tree_util
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/stack.py
+++ b/jax2onnx/plugins/jax/numpy/stack.py
@@ -7,12 +7,17 @@ from typing import ClassVar, Final, TypeAlias
 
 import jax
 from jax import tree_util
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    ad,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
-from jax.interpreters import ad, batching
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -154,9 +159,7 @@ class JnpStackPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        *in_avals: core.AbstractValue, axis: int, **_: object
-    ) -> core.ShapedArray:
+    def abstract_eval(*in_avals: AbstractValue, axis: int, **_: object) -> ShapedArray:
         if not in_avals:
             raise ValueError("jnp.stack requires at least one array")
 
@@ -175,9 +178,9 @@ class JnpStackPlugin(PrimitiveLeafPlugin):
 
         out_shape = list(ref_shape)
         out_shape.insert(axis_idx, len(in_avals))
-        return jax.core.ShapedArray(tuple(out_shape), ref_dtype)
+        return ShapedArray(tuple(out_shape), ref_dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         axis = int(getattr(eqn, "params", {}).get("axis", 0))
 
         input_vals: list[ir.Value] = []

--- a/jax2onnx/plugins/jax/numpy/sum.py
+++ b/jax2onnx/plugins/jax/numpy/sum.py
@@ -7,9 +7,13 @@ from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    ad,
+)
 import jax.numpy as jnp
-from jax.interpreters import ad
 import numpy as np
 from numpy.typing import ArrayLike
 
@@ -109,14 +113,14 @@ class JnpSumPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         axes: tuple[int, ...] | None = None,
         axes_is_tuple: bool = False,
         dtype: np.dtype[Any] | type | None = None,
         keepdims: bool = False,
         promote_integers: bool = True,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         return abstract_eval_via_orig_reduction(
             JnpSumPlugin._PRIM,
             JnpSumPlugin._FUNC_NAME,
@@ -128,7 +132,7 @@ class JnpSumPlugin(PrimitiveLeafPlugin):
             promote_integers=promote_integers,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = dict(getattr(eqn, "params", {}))
         in_dtype = np.dtype(getattr(getattr(eqn.invars[0], "aval", None), "dtype"))
         out_dtype = np.dtype(getattr(getattr(eqn.outvars[0], "aval", None), "dtype"))

--- a/jax2onnx/plugins/jax/numpy/sum.py
+++ b/jax2onnx/plugins/jax/numpy/sum.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/take.py
+++ b/jax2onnx/plugins/jax/numpy/take.py
@@ -11,8 +11,12 @@ import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
 from flax import nnx
-from jax import core
-from jax.interpreters import ad, batching
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+    ad,
+    batching,
+)
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -157,12 +161,12 @@ class JnpTakePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        arr: core.ShapedArray,
-        indices: core.ShapedArray,
+        arr: ShapedArray,
+        indices: ShapedArray,
         *,
         axis: int | None = None,
         mode: str | None = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         if mode is not None:
             raise NotImplementedError("jnp.take mode parameter is not supported")
         if axis is None:
@@ -170,9 +174,9 @@ class JnpTakePlugin(PrimitiveLeafPlugin):
         rank = len(arr.shape)
         axis_norm = _canonical_axis(int(axis), rank)
         out_shape = arr.shape[:axis_norm] + indices.shape + arr.shape[axis_norm + 1 :]
-        return core.ShapedArray(out_shape, arr.dtype)
+        return ShapedArray(out_shape, arr.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         axis_param = params.get("axis")
         mode = params.get("mode")

--- a/jax2onnx/plugins/jax/numpy/take.py
+++ b/jax2onnx/plugins/jax/numpy/take.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
 from flax import nnx
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
     ad,

--- a/jax2onnx/plugins/jax/numpy/tan.py
+++ b/jax2onnx/plugins/jax/numpy/tan.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -82,14 +86,14 @@ class JnpTanPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpTanPlugin._PRIM,
             JnpTanPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (x_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/numpy/tan.py
+++ b/jax2onnx/plugins/jax/numpy/tan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/tanh.py
+++ b/jax2onnx/plugins/jax/numpy/tanh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/tanh.py
+++ b/jax2onnx/plugins/jax/numpy/tanh.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 
@@ -80,14 +84,14 @@ class JnpTanhPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(x: core.AbstractValue) -> core.ShapedArray:
+    def abstract_eval(x: AbstractValue) -> ShapedArray:
         return abstract_eval_via_orig_unary(
             JnpTanhPlugin._PRIM,
             JnpTanhPlugin._FUNC_NAME,
             x,
         )
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         lower_unary_elementwise_with_optional_cast(
             ctx,
             eqn,

--- a/jax2onnx/plugins/jax/numpy/tile.py
+++ b/jax2onnx/plugins/jax/numpy/tile.py
@@ -6,12 +6,18 @@ from collections.abc import Callable, Sequence
 from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
-from jax import core, lax
+from jax import lax
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    Tracer,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
 import onnx_ir as ir
-from jax.interpreters import batching
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import (
@@ -232,21 +238,21 @@ class JnpTilePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        a: core.AbstractValue,
+        a: AbstractValue,
         *,
         reps: ArrayLike | None = None,
         repeats: ArrayLike | None = None,
         **_: object,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         repeats_spec = repeats if repeats is not None else reps
         if repeats_spec is None:
             raise ValueError("jnp.tile abstract_eval requires repeats/reps parameter")
         # Defer to the original implementation for robust symbolic-shape handling.
         spec = jax.ShapeDtypeStruct(a.shape, a.dtype)
         out = jax.eval_shape(lambda arr: _ORIG_TILE(arr, repeats_spec), spec)
-        return jax.core.ShapedArray(out.shape, out.dtype)
+        return ShapedArray(out.shape, out.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         input_var = eqn.invars[0]
         out_var = eqn.outvars[0]
         repeats_var = eqn.invars[1] if len(eqn.invars) > 1 else None
@@ -337,9 +343,7 @@ class JnpTilePlugin(PrimitiveLeafPlugin):
             setattr(cls._PRIM, storage_slot, orig)
 
             def _patched(a: ArrayLike, reps: ArrayLike) -> jax.Array:
-                if isinstance(reps, jax.Array) and not isinstance(
-                    reps, jax.core.Tracer
-                ):
+                if isinstance(reps, jax.Array) and not isinstance(reps, Tracer):
                     reps = np.asarray(reps)
                 if isinstance(reps, np.ndarray):
                     if reps.ndim == 0:

--- a/jax2onnx/plugins/jax/numpy/tile.py
+++ b/jax2onnx/plugins/jax/numpy/tile.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, Final, TypeAlias, cast
 
 import jax
 from jax import lax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/transpose.py
+++ b/jax2onnx/plugins/jax/numpy/transpose.py
@@ -7,7 +7,7 @@ from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
 import jax.numpy as jnp
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/transpose.py
+++ b/jax2onnx/plugins/jax/numpy/transpose.py
@@ -7,8 +7,12 @@ from typing import Callable, ClassVar, Final, TypeAlias
 
 import jax
 import jax.numpy as jnp
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -161,11 +165,11 @@ class JnpTransposePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         permutation: AxesArg = None,
         axes: AxesArg = None,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         rank = len(x.shape)
         if axes is not None and permutation is None:
             permutation = axes
@@ -175,9 +179,9 @@ class JnpTransposePlugin(PrimitiveLeafPlugin):
             )
         axes_tuple = _normalize_axes(permutation, rank)
         out_shape = tuple(x.shape[i] for i in axes_tuple)
-        return core.ShapedArray(out_shape, x.dtype)
+        return ShapedArray(out_shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (arr_var,) = eqn.invars
         (out_var,) = eqn.outvars
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/numpy/trilu.py
+++ b/jax2onnx/plugins/jax/numpy/trilu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/trilu.py
+++ b/jax2onnx/plugins/jax/numpy/trilu.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from typing import Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 from numpy.typing import ArrayLike
@@ -90,17 +94,17 @@ class JnpTriluPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        x: core.AbstractValue,
+        x: AbstractValue,
         *,
         k: int = 0,
         upper: bool = True,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del k, upper
         if len(x.shape) < 2:
             raise ValueError("jnp.triu/tril requires inputs with rank >= 2")
-        return core.ShapedArray(x.shape, x.dtype)
+        return ShapedArray(x.shape, x.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         k = _normalize_k(params.get("k", 0))
         upper = bool(params.get("upper", True))

--- a/jax2onnx/plugins/jax/numpy/unique.py
+++ b/jax2onnx/plugins/jax/numpy/unique.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, ClassVar, Final
 
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -114,19 +118,19 @@ class JnpUniquePlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        ar: core.AbstractValue,
+        ar: AbstractValue,
         *,
         size: int,
         fill_value: bool | int | float,
         sorted: bool = True,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         del fill_value, sorted
         size_int = int(size)
         if size_int < 0:
             raise ValueError("jnp.unique size must be non-negative")
-        return core.ShapedArray((size_int,), ar.dtype)
+        return ShapedArray((size_int,), ar.dtype)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = dict(getattr(eqn, "params", {}) or {})
         size_param = params.get("size")
         if size_param is None:

--- a/jax2onnx/plugins/jax/numpy/unique.py
+++ b/jax2onnx/plugins/jax/numpy/unique.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, ClassVar, Final
 
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/unstack.py
+++ b/jax2onnx/plugins/jax/numpy/unstack.py
@@ -7,8 +7,13 @@ from typing import Callable, ClassVar, Final, TypeAlias
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax import core
-from jax.interpreters import batching
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    InconclusiveDimensionOperation,
+    JaxprEqn,
+    ShapedArray,
+    batching,
+)
 from numpy.typing import ArrayLike
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
@@ -157,20 +162,18 @@ class JnpUnstackPlugin(PrimitiveLeafPlugin):
     _ABSTRACT_EVAL_BOUND: ClassVar[bool] = False
 
     @staticmethod
-    def abstract_eval(
-        x: jax.core.AbstractValue, *, axis: int = 0
-    ) -> tuple[jax.core.ShapedArray, ...]:
+    def abstract_eval(x: AbstractValue, *, axis: int = 0) -> tuple[ShapedArray, ...]:
         rank = len(x.shape)
         axis_norm = _normalize_axis(axis, rank)
         size = x.shape[axis_norm]
         if not isinstance(size, (int, np.integer)):
-            raise core.InconclusiveDimensionOperation(
+            raise InconclusiveDimensionOperation(
                 "jnp.unstack requires static axis length"
             )
         out_shape = x.shape[:axis_norm] + x.shape[axis_norm + 1 :]
-        return tuple(core.ShapedArray(out_shape, x.dtype) for _ in range(int(size)))
+        return tuple(ShapedArray(out_shape, x.dtype) for _ in range(int(size)))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         params = getattr(eqn, "params", {})
         axis_param = params.get("axis", 0)
 

--- a/jax2onnx/plugins/jax/numpy/unstack.py
+++ b/jax2onnx/plugins/jax/numpy/unstack.py
@@ -7,7 +7,7 @@ from typing import Callable, ClassVar, Final, TypeAlias
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     InconclusiveDimensionOperation,
     JaxprEqn,

--- a/jax2onnx/plugins/jax/numpy/where.py
+++ b/jax2onnx/plugins/jax/numpy/where.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
     Var,

--- a/jax2onnx/plugins/jax/numpy/where.py
+++ b/jax2onnx/plugins/jax/numpy/where.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final, cast
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+    Var,
+    ad,
+    batching,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.interpreters import ad, batching
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
@@ -275,18 +280,18 @@ class JnpWherePlugin(PrimitiveLeafPlugin):
         x: object,
         y: object,
         **_: object,
-    ) -> core.ShapedArray:
-        if not isinstance(cond, core.ShapedArray):
+    ) -> ShapedArray:
+        if not isinstance(cond, ShapedArray):
             raise TypeError("jnp.where expects ShapedArray inputs")
-        if not isinstance(x, core.ShapedArray):
+        if not isinstance(x, ShapedArray):
             raise TypeError("jnp.where expects ShapedArray inputs")
-        if not isinstance(y, core.ShapedArray):
+        if not isinstance(y, ShapedArray):
             raise TypeError("jnp.where expects ShapedArray inputs")
         promoted = np.promote_types(x.dtype, y.dtype)
         out_shape = jnp.broadcast_shapes(cond.shape, x.shape, y.shape)
-        return core.ShapedArray(out_shape, promoted)
+        return ShapedArray(out_shape, promoted)
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         cond_var, x_var, y_var = eqn.invars
         out_var = eqn.outvars[0]
 
@@ -351,7 +356,7 @@ class JnpWherePlugin(PrimitiveLeafPlugin):
     def _maybe_cast(
         ctx: LoweringContextProtocol,
         value: ir.Value,
-        var: core.Var,
+        var: Var,
         target_dtype: np.dtype[Any],
         tag: str,
     ) -> ir.Value:

--- a/jax2onnx/plugins/jax/numpy/windows.py
+++ b/jax2onnx/plugins/jax/numpy/windows.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
-from jax.extend.core import Primitive
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -61,11 +64,11 @@ class _WindowBasePlugin(PrimitiveLeafPlugin):
         *,
         n: int,
         dtype: np.dtype[Any] | type = np.float32,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         n_i = _window_size(n)
-        return core.ShapedArray((n_i,), np.dtype(dtype))
+        return ShapedArray((n_i,), np.dtype(dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})
 
@@ -340,11 +343,11 @@ class JnpBartlettPlugin(PrimitiveLeafPlugin):
         *,
         n: int,
         dtype: np.dtype[Any] | type = np.float32,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         n_i = _window_size(n)
-        return core.ShapedArray((n_i,), np.dtype(dtype))
+        return ShapedArray((n_i,), np.dtype(dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})
         n_i = _window_size(params.get("n"))

--- a/jax2onnx/plugins/jax/numpy/windows.py
+++ b/jax2onnx/plugins/jax/numpy/windows.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     Primitive,
     ShapedArray,

--- a/jax2onnx/plugins/jax/numpy/zeros.py
+++ b/jax2onnx/plugins/jax/numpy/zeros.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     JaxprEqn,
     ShapedArray,
 )

--- a/jax2onnx/plugins/jax/numpy/zeros.py
+++ b/jax2onnx/plugins/jax/numpy/zeros.py
@@ -6,7 +6,10 @@ from collections.abc import Sequence as _Seq
 from typing import Any, Callable, ClassVar, Final
 
 import jax
-from jax import core
+from jax2onnx.plugins.jax._jax_compat import (
+    JaxprEqn,
+    ShapedArray,
+)
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
@@ -71,11 +74,11 @@ class JnpZerosPlugin(PrimitiveLeafPlugin):
         *,
         shape: tuple[int, ...],
         dtype: np.dtype[Any] | type,
-    ) -> core.ShapedArray:
+    ) -> ShapedArray:
         dims = _normalize_shape(shape)
-        return core.ShapedArray(dims, np.dtype(dtype))
+        return ShapedArray(dims, np.dtype(dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (out_var,) = eqn.outvars
         params = dict(getattr(eqn, "params", {}) or {})
 

--- a/jax2onnx/plugins/jax/random/bernoulli.py
+++ b/jax2onnx/plugins/jax/random/bernoulli.py
@@ -8,13 +8,18 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.extend.core import Primitive
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy, numpy_dtype_to_ir
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -76,19 +81,19 @@ class RandomBernoulliPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        key: jax.core.AbstractValue,
-        p: jax.core.AbstractValue,
+        key: AbstractValue,
+        p: AbstractValue,
         *,
         shape: tuple[int, ...] | None = None,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del key
         if shape is None:
             out_shape = tuple(getattr(p, "shape", ()))
         else:
             out_shape = tuple(int(d) for d in shape)
-        return jax.core.ShapedArray(out_shape, np.dtype(np.bool_))
+        return ShapedArray(out_shape, np.dtype(np.bool_))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         key_var, p_var = eqn.invars
         (out_var,) = eqn.outvars
         shape_param = eqn.params.get("shape", None)

--- a/jax2onnx/plugins/jax/random/bernoulli.py
+++ b/jax2onnx/plugins/jax/random/bernoulli.py
@@ -14,7 +14,7 @@ from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.ir_utils import ir_dtype_to_numpy, numpy_dtype_to_ir
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/random/categorical.py
+++ b/jax2onnx/plugins/jax/random/categorical.py
@@ -13,7 +13,7 @@ from numpy.typing import ArrayLike
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/random/categorical.py
+++ b/jax2onnx/plugins/jax/random/categorical.py
@@ -8,12 +8,17 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.extend.core import Primitive
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins.jax.lax._index_utils import _const_i64
 
@@ -203,14 +208,14 @@ class RandomCategoricalPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        key: jax.core.AbstractValue,
-        logits: jax.core.AbstractValue,
+        key: AbstractValue,
+        logits: AbstractValue,
         *,
         axis: int = -1,
         shape: tuple[int, ...] | None = None,
         replace: bool = True,
         mode: str | None = None,
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del key, replace, mode
         logits_shape = tuple(getattr(logits, "shape", ()))
         logits_rank = len(logits_shape)
@@ -219,9 +224,9 @@ class RandomCategoricalPlugin(PrimitiveLeafPlugin):
             out_shape = logits_shape[:axis_norm] + logits_shape[axis_norm + 1 :]
         else:
             out_shape = tuple(int(d) for d in shape)
-        return jax.core.ShapedArray(out_shape, np.dtype(np.int32))
+        return ShapedArray(out_shape, np.dtype(np.int32))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         key_var, logits_var = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/random/normal.py
+++ b/jax2onnx/plugins/jax/random/normal.py
@@ -8,13 +8,18 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import onnx_ir as ir
-from jax.extend.core import Primitive
 from numpy.typing import ArrayLike
 
 from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
+from jax2onnx.plugins.jax._jax_compat import (
+    AbstractValue,
+    JaxprEqn,
+    Primitive,
+    ShapedArray,
+)
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -64,16 +69,16 @@ class RandomNormalPlugin(PrimitiveLeafPlugin):
 
     @staticmethod
     def abstract_eval(
-        key: jax.core.AbstractValue,
+        key: AbstractValue,
         *,
         shape: tuple[int, ...] = (),
         dtype: np.dtype = np.dtype(np.float32),
-    ) -> jax.core.ShapedArray:
+    ) -> ShapedArray:
         del key
         out_shape = tuple(int(dim) for dim in shape)
-        return jax.core.ShapedArray(out_shape, np.dtype(dtype))
+        return ShapedArray(out_shape, np.dtype(dtype))
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         (key_var,) = eqn.invars
         (out_var,) = eqn.outvars
 

--- a/jax2onnx/plugins/jax/random/normal.py
+++ b/jax2onnx/plugins/jax/random/normal.py
@@ -14,7 +14,7 @@ from jax2onnx.converter.ir_builder import _dtype_to_ir
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     AbstractValue,
     JaxprEqn,
     Primitive,

--- a/jax2onnx/plugins/jax/random/random_bits.py
+++ b/jax2onnx/plugins/jax/random/random_bits.py
@@ -14,6 +14,7 @@ import jax
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _stamp_type_and_shape
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 
 
@@ -75,7 +76,7 @@ def _scalar_constant(ctx: LoweringContextProtocol, value: float) -> ir.Value:
 class RandomBitsPlugin(PrimitiveLeafPlugin):
     """Lower ``random_bits`` via RandomUniformLike + scaling + cast."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         key_var = eqn.invars[0]
         out_var = eqn.outvars[0]
         params = getattr(eqn, "params", {})

--- a/jax2onnx/plugins/jax/random/random_bits.py
+++ b/jax2onnx/plugins/jax/random/random_bits.py
@@ -14,7 +14,7 @@ import jax
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.plugins._ir_shapes import _stamp_type_and_shape
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 
 

--- a/jax2onnx/plugins/jax/random/random_fold_in.py
+++ b/jax2onnx/plugins/jax/random/random_fold_in.py
@@ -14,10 +14,10 @@ from typing import cast
 
 import numpy as np
 import onnx_ir as ir
-import jax
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.converter.typing_support import LoweringContextProtocol
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -66,7 +66,7 @@ def _identity(
 class RandomFoldInPlugin(PrimitiveLeafPlugin):
     """Forward the incoming key; sufficient for deterministic inference paths."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         key_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 

--- a/jax2onnx/plugins/jax/random/random_fold_in.py
+++ b/jax2onnx/plugins/jax/random/random_fold_in.py
@@ -17,7 +17,7 @@ import onnx_ir as ir
 
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.converter.typing_support import LoweringContextProtocol
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/jax/random/random_seed.py
+++ b/jax2onnx/plugins/jax/random/random_seed.py
@@ -14,6 +14,7 @@ import jax
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import DimInput
+from jax2onnx.plugins.jax._jax_compat import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 
@@ -100,7 +101,7 @@ def _unsqueeze(ctx: LoweringContextProtocol, value: ir.Value, axis: int) -> ir.V
 class RandomSeedPlugin(PrimitiveLeafPlugin):
     """Lower ``random_seed`` to a deterministic uint32 key pair [0, seed]."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         seed_var = eqn.invars[0]
         out_var = eqn.outvars[0]
 
@@ -155,7 +156,7 @@ class RandomSeedPlugin(PrimitiveLeafPlugin):
 class RandomUnwrapPlugin(PrimitiveLeafPlugin):
     """Forward the uint32 key produced by ``random_seed``."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         key_var = eqn.invars[0]
         out_var = eqn.outvars[0]
         key_value = ctx.get_value_for_var(key_var, name_hint=ctx.fresh_name("prng"))
@@ -179,7 +180,7 @@ class RandomUnwrapPlugin(PrimitiveLeafPlugin):
 class RandomWrapPlugin(PrimitiveLeafPlugin):
     """No-op wrapper around PRNG keys."""
 
-    def lower(self, ctx: LoweringContextProtocol, eqn: jax.core.JaxprEqn) -> None:
+    def lower(self, ctx: LoweringContextProtocol, eqn: JaxprEqn) -> None:
         key_var = eqn.invars[0]
         out_var = eqn.outvars[0]
         key_value = ctx.get_value_for_var(key_var, name_hint=ctx.fresh_name("prng"))

--- a/jax2onnx/plugins/jax/random/random_seed.py
+++ b/jax2onnx/plugins/jax/random/random_seed.py
@@ -14,7 +14,7 @@ import jax
 from jax2onnx.plugins._post_check_onnx_graph import expect_graph as EG
 from jax2onnx.converter.typing_support import LoweringContextProtocol
 from jax2onnx.plugins._ir_shapes import DimInput
-from jax2onnx.plugins.jax._jax_compat import JaxprEqn
+from jax2onnx._compat.jax import JaxprEqn
 from jax2onnx.plugins.plugin_system import PrimitiveLeafPlugin, register_primitive
 
 

--- a/jax2onnx/plugins/plugin_system.py
+++ b/jax2onnx/plugins/plugin_system.py
@@ -35,7 +35,7 @@ import numpy as np
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec, apply_patches
 from jax2onnx.plugins.jax._autodiff_utils import backfill_missing_transpose_rules
-from jax2onnx.plugins.jax._jax_compat import (
+from jax2onnx._compat.jax import (
     NOT_MAPPED,
     Primitive,
     ShapedArray,

--- a/jax2onnx/plugins/plugin_system.py
+++ b/jax2onnx/plugins/plugin_system.py
@@ -31,15 +31,18 @@ from typing import (
 
 import jax
 import jax.tree_util as jtu
-from jax.extend import core as jcore_ext
 import numpy as np
-from jax.core import ShapedArray
-from jax.extend.core import Primitive
-from jax.interpreters import batching
 
 from jax2onnx.plugins._patching import AssignSpec, MonkeyPatchSpec, apply_patches
 from jax2onnx.plugins.jax._autodiff_utils import backfill_missing_transpose_rules
-from jax2onnx.plugins.jax._batching_compat import ensure_batching_not_mapped_attr
+from jax2onnx.plugins.jax._jax_compat import (
+    NOT_MAPPED,
+    Primitive,
+    ShapedArray,
+    Var,
+    batching,
+    ensure_batching_not_mapped_attr,
+)
 from jax2onnx.converter.function_scope import FunctionScope, FunctionKey
 from jax2onnx.converter.lowering_dispatch import (
     lower_jaxpr_with_plugins,
@@ -582,7 +585,7 @@ class FunctionPlugin(PrimitivePlugin):
 
         axis_size: Any | None = None
         for arg, bdim in zip(args, dims):
-            if bdim is batching.not_mapped:
+            if bdim is NOT_MAPPED:
                 continue
             shape = getattr(arg, "shape", None)
             if shape is None or bdim >= len(shape):
@@ -592,7 +595,7 @@ class FunctionPlugin(PrimitivePlugin):
 
         if axis_size is None:
             result = original_fn(*args, **call_kwargs)
-            out_dims = jtu.tree_map(lambda _: batching.not_mapped, result)
+            out_dims = jtu.tree_map(lambda _: NOT_MAPPED, result)
             return result, out_dims
 
         prepared_args = [
@@ -895,7 +898,7 @@ class FunctionPlugin(PrimitivePlugin):
                 else None
             )
 
-            if isinstance(resolved, jcore_ext.Var):
+            if isinstance(resolved, Var):
                 dynamic_entries.append(
                     {
                         "name": pname,

--- a/poetry.lock
+++ b/poetry.lock
@@ -711,7 +711,7 @@ description = "Easily serialize dataclasses to and from JSON."
 optional = false
 python-versions = "<4.0,>=3.7"
 groups = ["main"]
-markers = "python_version <= \"3.13\""
+markers = "python_version < \"3.14\""
 files = [
     {file = "dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a"},
     {file = "dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0"},
@@ -2056,7 +2056,7 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.26.0", markers = "python_version == \"3.12\""},
     {version = ">=1.23.3", markers = "python_version == \"3.11\""},
 ]
 
@@ -2474,7 +2474,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = false
 python-versions = "!=3.14.1,>=3.11"
 groups = ["test"]
-markers = "python_version <= \"3.13\""
+markers = "python_version < \"3.14\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -2592,7 +2592,7 @@ description = "CUBLAS native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728"},
     {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-win_amd64.whl", hash = "sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906"},
@@ -2605,7 +2605,7 @@ description = "CUDA profiling tools runtime libs."
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e"},
     {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4"},
@@ -2618,7 +2618,7 @@ description = "NVRTC native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2"},
     {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed"},
@@ -2631,7 +2631,7 @@ description = "CUDA Runtime native Libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40"},
     {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344"},
@@ -2644,7 +2644,7 @@ description = "cuDNN runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f"},
     {file = "nvidia_cudnn_cu12-9.1.0.70-py3-none-win_amd64.whl", hash = "sha256:6278562929433d68365a07a4a1546c237ba2849852c0d4b2262a486e805b977a"},
@@ -2660,7 +2660,7 @@ description = "CUFFT native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56"},
     {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-win_amd64.whl", hash = "sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253"},
@@ -2673,7 +2673,7 @@ description = "CURAND native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0"},
     {file = "nvidia_curand_cu12-10.3.2.106-py3-none-win_amd64.whl", hash = "sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a"},
@@ -2686,7 +2686,7 @@ description = "CUDA solver native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd"},
     {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-win_amd64.whl", hash = "sha256:74e0c3a24c78612192a74fcd90dd117f1cf21dea4822e66d89e8ea80e3cd2da5"},
@@ -2704,7 +2704,7 @@ description = "CUSPARSE native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c"},
     {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-win_amd64.whl", hash = "sha256:b798237e81b9719373e8fae8d4f091b70a0cf09d9d85c95a557e11df2d8e9a5a"},
@@ -2720,7 +2720,7 @@ description = "NVIDIA Collective Communication Library (NCCL) Runtime"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1fc150d5c3250b170b29410ba682384b14581db722b2531b0d8d33c595f33d01"},
     {file = "nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:057f6bf9685f75215d0c53bf3ac4a10b3e6578351de307abad9e18a99182af56"},
@@ -2733,7 +2733,7 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9"},
     {file = "nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca"},
@@ -2747,7 +2747,7 @@ description = "NVIDIA Tools Extension"
 optional = false
 python-versions = ">=3"
 groups = ["test"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5"},
     {file = "nvidia_nvtx_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82"},
@@ -3020,7 +3020,7 @@ files = [
 [package.dependencies]
 typing-extensions = [
     {version = ">=4.12.0", markers = "python_version >= \"3.13\""},
-    {version = ">=4.6.0", markers = "python_version < \"3.13\""},
+    {version = ">=4.6.0"},
 ]
 
 [package.extras]
@@ -5689,4 +5689,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "34cdca1a60c61b95c2cbbb1ebdfff5b8c0a8614c53bdfedbe3fdf0f9e4f44d6c"
+content-hash = "ccc2a266ca0897b9fcde14596aaed82cdba173aa5e2ecbbd0899ba2f39498718"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "enpasos", email = "matthias.unverzagt@enpasos.ai" }]
 readme = "README.md"
 requires-python = ">=3.11"  # Flax requires >=3.11, and we test 3.11, 3.12, 3.13 and 3.14
 dependencies = [
-    "jax>=0.7.2",
+    "jax>=0.8.1",
     "flax>=0.12.1",
     "ml_dtypes>=0.5.1",
     "optax>=0.2.4",
@@ -34,7 +34,7 @@ torch = "==2.4.0"
 optional = true
 
 [tool.poetry.group.gpu.dependencies]
-jax = { version = ">=0.7.2", extras = ["cuda12_pip"] }
+jax = { version = ">=0.8.1", extras = ["cuda12_pip"] }
 
 
 [tool.poetry.group.maxtext]

--- a/scripts/install_minimum_dependencies.py
+++ b/scripts/install_minimum_dependencies.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# scripts/install_minimum_dependencies.py
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Sequence
+
+
+_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+(?:\[[A-Za-z0-9_.\-,]+\])?)")
+_BOUND_RE = re.compile(r"(==|>=)\s*([^,;\s]+)")
+
+
+def minimum_requirement(dependency: str) -> str:
+    """Return an exact lower-bound requirement for a PEP 508 dependency string."""
+
+    unmarked = dependency.split(";", 1)[0].strip()
+    name_match = _NAME_RE.match(unmarked)
+    if name_match is None:
+        raise ValueError(f"Cannot parse dependency name from {dependency!r}")
+    name = name_match.group(1)
+
+    for operator, version in _BOUND_RE.findall(unmarked):
+        if operator in {"==", ">="}:
+            return f"{name}=={version}"
+    raise ValueError(f"Dependency {dependency!r} has no exact or lower bound")
+
+
+def minimum_requirements(pyproject_path: Path) -> list[str]:
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    dependencies = pyproject.get("project", {}).get("dependencies", [])
+    if not isinstance(dependencies, list):
+        raise TypeError("[project].dependencies must be a list")
+    return [minimum_requirement(str(dependency)) for dependency in dependencies]
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install direct runtime dependencies at the minimum versions declared "
+            "in pyproject.toml."
+        )
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the pip command without installing anything.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    requirements = minimum_requirements(args.pyproject)
+    command = [sys.executable, "-m", "pip", "install", *requirements]
+
+    if args.dry_run:
+        print(" ".join(command))
+        return 0
+
+    subprocess.run(command, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/extra_tests/framework/test_jax_compat.py
+++ b/tests/extra_tests/framework/test_jax_compat.py
@@ -1,0 +1,21 @@
+# tests/extra_tests/framework/test_jax_compat.py
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from jax2onnx.plugins.jax import _jax_compat as compat
+
+
+def test_jax_compat_exports_core_types() -> None:
+    prim = compat.Primitive("jax2onnx_test_compat")
+    aval = compat.ShapedArray((2, 3), jnp.float32)
+
+    assert prim.name == "jax2onnx_test_compat"
+    assert aval.shape == (2, 3)
+    assert aval.dtype == jnp.float32
+
+
+def test_jax_compat_exposes_not_mapped_alias() -> None:
+    assert compat.ensure_batching_not_mapped_attr() is compat.NOT_MAPPED
+    assert compat.batching.not_mapped is compat.NOT_MAPPED

--- a/tests/extra_tests/framework/test_jax_compat.py
+++ b/tests/extra_tests/framework/test_jax_compat.py
@@ -19,3 +19,8 @@ def test_jax_compat_exports_core_types() -> None:
 def test_jax_compat_exposes_not_mapped_alias() -> None:
     assert compat.ensure_batching_not_mapped_attr() is compat.NOT_MAPPED
     assert compat.batching.not_mapped is compat.NOT_MAPPED
+
+
+def test_jax_compat_exposes_shape_equality_helper() -> None:
+    assert compat.definitely_equal_shape((2, 3), (2, 3))
+    assert not compat.definitely_equal_shape((2, 3), (2, 4))

--- a/tests/extra_tests/framework/test_jax_compat.py
+++ b/tests/extra_tests/framework/test_jax_compat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 
-from jax2onnx.plugins.jax import _jax_compat as compat
+from jax2onnx._compat import jax as compat
 
 
 def test_jax_compat_exports_core_types() -> None:

--- a/tests/extra_tests/framework/test_minimum_dependency_installer.py
+++ b/tests/extra_tests/framework/test_minimum_dependency_installer.py
@@ -1,0 +1,29 @@
+# tests/extra_tests/framework/test_minimum_dependency_installer.py
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.install_minimum_dependencies import (
+    minimum_requirement,
+    minimum_requirements,
+)
+
+
+def test_minimum_requirement_extracts_lower_bound_with_upper_bound() -> None:
+    assert (
+        minimum_requirement("orbax-checkpoint>=0.11.6,<0.11.37")
+        == "orbax-checkpoint==0.11.6"
+    )
+
+
+def test_minimum_requirement_preserves_extras() -> None:
+    assert minimum_requirement("jax[cuda12_pip]>=0.7.2") == "jax[cuda12_pip]==0.7.2"
+
+
+def test_project_runtime_dependencies_all_have_minimum_versions() -> None:
+    requirements = minimum_requirements(Path("pyproject.toml"))
+
+    assert "jax==0.7.2" in requirements
+    assert "flax==0.12.1" in requirements
+    assert all("==" in requirement for requirement in requirements)

--- a/tests/extra_tests/framework/test_minimum_dependency_installer.py
+++ b/tests/extra_tests/framework/test_minimum_dependency_installer.py
@@ -18,12 +18,12 @@ def test_minimum_requirement_extracts_lower_bound_with_upper_bound() -> None:
 
 
 def test_minimum_requirement_preserves_extras() -> None:
-    assert minimum_requirement("jax[cuda12_pip]>=0.7.2") == "jax[cuda12_pip]==0.7.2"
+    assert minimum_requirement("jax[cuda12_pip]>=0.8.1") == "jax[cuda12_pip]==0.8.1"
 
 
 def test_project_runtime_dependencies_all_have_minimum_versions() -> None:
     requirements = minimum_requirements(Path("pyproject.toml"))
 
-    assert "jax==0.7.2" in requirements
+    assert "jax==0.8.1" in requirements
     assert "flax==0.12.1" in requirements
     assert all("==" in requirement for requirement in requirements)


### PR DESCRIPTION
## What changed

- Added a package-level JAX compatibility module for moving JAX core/internal symbols.
- Migrated core JAX, JNP, LAX, NNX, Linen, and related plugin imports away from direct `jax.core` / `jax.extend.core` usage where applicable.
- Added a dedicated CI job that installs direct runtime dependencies at their declared minimum versions.
- Raised the declared minimum JAX version to `jax>=0.8.1`, because `flax>=0.12.1` requires `jax>=0.8.1` and the previous `jax>=0.7.2` lower bound was not installable with the declared Flax minimum.
- Added parser coverage for the minimum-dependency installer.
- Updated the upcoming-version roadmap notes for the JAX compatibility and minimum-version CI work.

## Why

This keeps the upcoming upgrade path compatible with both the declared minimum stack and newer JAX releases, while making private/internal JAX API moves easier to handle in one place.

## Validation

- Focused plugin test blocks during the migration, including Linen full suite: `216 passed`.
- `tests/extra_tests/test_bfloat16_capability_matrix.py`: `20 passed`.
- `tests/extra_tests/framework/test_jax_compat.py` and `test_minimum_dependency_installer.py`: `6 passed`.
- `poetry check` after regenerating `poetry.lock`.
- Minimal dependency dry-run resolves `jax==0.8.1` with `flax==0.12.1`.
- `poetry run mkdocs build --strict`.
- `./scripts/check_typing.sh`.
- `ruff`, `black`, `git diff --check`, and generated-artifact checks.
- PR CI is green on the current head: `onnxruntime-web smoke`, `minimum dependency versions`, and Python `3.11` through `3.14`.