### PR TITLE
[codex] Guard JAX compat Literal fallback

### DIFF
--- a/jax2onnx/_compat/jax.py
+++ b/jax2onnx/_compat/jax.py
@@ -28,10 +28,15 @@ except AttributeError:  # pragma: no cover - compatibility with older JAX versio
 
 
 def _resolve_literal_type() -> type[Any]:
-    try:
-        return cast(type[Any], jax_core_ext.Literal)
-    except AttributeError:  # pragma: no cover - compatibility with older JAX versions
-        return cast(type[Any], jax_core.Literal)
+    literal_type = getattr(jax_core_ext, "Literal", None)
+    if isinstance(literal_type, type):
+        return cast(type[Any], literal_type)
+    literal_type = getattr(jax_core, "Literal", None)
+    if isinstance(literal_type, type):
+        return cast(type[Any], literal_type)
+    from jax._src import core as jax_core_src
+
+    return cast(type[Any], jax_core_src.Literal)
 
 
 if TYPE_CHECKING:

--- a/jax2onnx/_compat/jax.py
+++ b/jax2onnx/_compat/jax.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from jax import core as jax_core
 
@@ -13,7 +13,7 @@ try:  # JAX 0.10+ exposes this through jax.errors.
 except ImportError:  # pragma: no cover - compatibility with older JAX versions
     from jax.core import InconclusiveDimensionOperation
 from jax.extend import core as jax_core_ext
-from jax.extend.core import ClosedJaxpr, Jaxpr, JaxprEqn, Literal, Primitive
+from jax.extend.core import ClosedJaxpr, Jaxpr, JaxprEqn, Primitive
 from jax.interpreters import ad, batching
 
 
@@ -25,6 +25,19 @@ try:
     DropVar = jax_core_ext.DropVar
 except AttributeError:  # pragma: no cover - compatibility with older JAX versions
     DropVar = jax_core.DropVar
+
+
+def _resolve_literal_type() -> type[Any]:
+    try:
+        return cast(type[Any], jax_core_ext.Literal)
+    except AttributeError:  # pragma: no cover - compatibility with older JAX versions
+        return cast(type[Any], jax_core.Literal)
+
+
+if TYPE_CHECKING:
+    from jax.extend.core import Literal as Literal
+else:
+    Literal = _resolve_literal_type()
 
 
 def dim_constant(value: int) -> Any:

--- a/tests/extra_tests/framework/test_jax_compat.py
+++ b/tests/extra_tests/framework/test_jax_compat.py
@@ -18,16 +18,15 @@ def test_jax_compat_exports_core_types() -> None:
     assert isinstance(compat.Literal, type)
 
 
-def test_jax_compat_literal_falls_back_to_jax_core(
+def test_jax_compat_literal_falls_back_to_jax_src_core(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    class FallbackLiteral:
-        pass
+    from jax._src import core as jax_core_src
 
     monkeypatch.delattr(compat.jax_core_ext, "Literal", raising=False)
-    monkeypatch.setattr(compat.jax_core, "Literal", FallbackLiteral, raising=False)
+    monkeypatch.delattr(compat.jax_core, "Literal", raising=False)
 
-    assert compat._resolve_literal_type() is FallbackLiteral
+    assert compat._resolve_literal_type() is jax_core_src.Literal
 
 
 def test_jax_compat_exposes_not_mapped_alias() -> None:

--- a/tests/extra_tests/framework/test_jax_compat.py
+++ b/tests/extra_tests/framework/test_jax_compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+from pytest import MonkeyPatch
 
 from jax2onnx._compat import jax as compat
 
@@ -14,6 +15,19 @@ def test_jax_compat_exports_core_types() -> None:
     assert prim.name == "jax2onnx_test_compat"
     assert aval.shape == (2, 3)
     assert aval.dtype == jnp.float32
+    assert isinstance(compat.Literal, type)
+
+
+def test_jax_compat_literal_falls_back_to_jax_core(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    class FallbackLiteral:
+        pass
+
+    monkeypatch.delattr(compat.jax_core_ext, "Literal", raising=False)
+    monkeypatch.setattr(compat.jax_core, "Literal", FallbackLiteral, raising=False)
+
+    assert compat._resolve_literal_type() is FallbackLiteral
 
 
 def test_jax_compat_exposes_not_mapped_alias() -> None:


### PR DESCRIPTION
## What changed

- Stop importing Literal directly from jax.extend.core at module import time.
- Resolve Literal through jax.extend.core when present and fall back to jax.core.Literal for older JAX layouts.
- Keep static typing intact via a TYPE_CHECKING import while runtime uses the compatibility resolver.
- Add focused coverage for the fallback behavior.

## Why

Copilot flagged that jax.extend.core.Literal may be absent on some supported JAX versions. A hard import in jax2onnx._compat.jax would make the central compat module fail during import and break all downstream users.

## Validation

- poetry run pytest -q tests/extra_tests/framework/test_jax_compat.py
- poetry run ruff check jax2onnx/_compat/jax.py tests/extra_tests/framework/test_jax_compat.py
- poetry run black --check jax2onnx/_compat/jax.py tests/extra_tests/framework/test_jax_compat.py
- ./scripts/check_typing.sh
- git diff --check