### PR TITLE
Document RL policy deployment contract

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -9,8 +9,8 @@
   CPU and Web/WASM flows, especially for mobile deployments where practical.
 * Broaden capability-matrix coverage across dtype and shape variants, including
   BF16, dynamic dimensions, and non-square inputs.
-* Add focused end-to-end deployment examples for small vision, RL-style, and
-  numerical models.
+* Add focused end-to-end deployment examples for small vision and numerical
+  models.
 * Continue targeted coverage work for JAX, Flax NNX/Linen, Equinox, SotA
   examples, and physics/simulation use cases.
 
@@ -18,9 +18,14 @@
 
 ### **jax2onnx 0.14.2**
 
-* **Add deterministic RL policy examples:** Provide continuous-control and
-  discrete-control `examples.rl` exports that validate an `obs -> action`
-  deployment contract through the standard generated example-test path.
+* **Add deterministic RL policy exports:** Provide continuous-control and
+  discrete-control `examples.rl` exports for the `obs -> action` deployment
+  contract, documented with RL policy-only guidance and validated through the
+  standard generated example-test path.
+* **Harden generated example runtime contracts:** Add optional ONNX shape
+  inference and runtime contract hooks to example metadata so deployment
+  examples can validate extra concrete batch sizes, output dtype/shape, and
+  domain-specific output constraints without separate test trees.
 
 ## Current Version
 

--- a/docs/developer_guide/plugin_system.md
+++ b/docs/developer_guide/plugin_system.md
@@ -311,6 +311,8 @@ Common testcase fields:
 | `expected_output_shapes` | Output shape assertions after export. |
 | `expected_output_dtypes` | Output dtype assertions after export. |
 | `post_check_onnx_graph` | `expect_graph(...)` structural predicate. |
+| `runtime_input_values` | Additional concrete input sets for ONNX Runtime contract checks. |
+| `post_check_onnx_runtime` | Callable invoked with runtime inputs and ONNX outputs for per-example contracts. |
 | `run_only_dynamic` | Skip the concrete variant for symbolic-shape tests. |
 | `run_only_f32_variant` | Skip generated f64 variant. |
 | `run_only_f64_variant` | Generate only the f64 variant. |
@@ -320,6 +322,7 @@ Common testcase fields:
 | `input_names` / `output_names` | Public graph IO name overrides. |
 | `skip_numeric_validation` | Keep export/structure checks but skip runtime allclose. |
 | `check_onnx_load` | Run ONNX checker after serialization. |
+| `check_onnx_shape_inference` | Run ONNX shape inference after serialization. |
 | `expected_number_of_function_instances` | Assert expected FunctionProto count for ONNX Function tests. |
 
 `callable_factory` is no longer supported. Use `construct_and_call(...)` so the

--- a/docs/user_guide/rl_policy_deployment.md
+++ b/docs/user_guide/rl_policy_deployment.md
@@ -1,0 +1,171 @@
+# RL Policy Deployment
+
+Use this pattern when exporting a trained reinforcement-learning policy for
+inference. The deployment callable should be a small deterministic actor with a
+plain public interface:
+
+```text
+obs -> action
+```
+
+Keep training state, optimizer state, PRNG keys, rollout loops, and environment
+state outside the exported callable. Freeze or close over policy parameters so
+they become constants or initializers in the ONNX model, not runtime inputs.
+
+The reference examples are listed in [Examples](examples.md):
+
+- `ContinuousTanhPolicy`: `obs -> tanh(mean_action)`
+- `DiscreteArgmaxPolicy`: `obs -> argmax(logits)`
+
+Both are registered as `examples.rl` exports and run through the standard
+generated example-test path.
+
+## Export Contract
+
+A deployment-ready RL policy should make these choices explicit:
+
+- Input name: `obs`
+- Output name: `action`
+- Dynamic batch: use a symbolic leading dimension such as `"B"`
+- No runtime inputs named `key`, `rng`, `params`, `train_state`,
+  `deterministic`, `training`, or `mutable`
+- No stochastic sampling in the exported graph
+- No `Dropout` or ONNX random operators in the exported graph
+
+For continuous-control policies, bound the final action if the runtime expects
+an actuator range:
+
+```python
+import jax.numpy as jnp
+
+
+def continuous_policy(obs):
+    h = jnp.tanh(obs @ w1 + b1)
+    mean_action = h @ w2 + b2
+    return jnp.tanh(mean_action)
+```
+
+For discrete-control policies, choose the action-index dtype intentionally and
+validate it against the target runtime:
+
+```python
+import jax.numpy as jnp
+
+
+def discrete_policy(obs):
+    h = jnp.tanh(obs @ w1 + b1)
+    logits = h @ w2 + b2
+    return jnp.argmax(logits, axis=-1).astype(jnp.int32)
+```
+
+## Export
+
+Use `input_names` and `output_names` so the ONNX interface stays stable for the
+serving code:
+
+```python
+from pathlib import Path
+
+from jax2onnx import to_onnx
+
+OBS_DIM = 17
+model_path = Path("policy.onnx")
+
+to_onnx(
+    continuous_policy,
+    inputs=[("B", OBS_DIM)],
+    input_names=["obs"],
+    output_names=["action"],
+    return_mode="file",
+    output_path=str(model_path),
+)
+```
+
+The callable may be a function, a bound module, or a small wrapper around a
+trained actor. The important part is that the exported callable has already been
+reduced to inference behavior.
+
+## Validate
+
+Start with the general deployment checks from
+[Validation & Deployment Readiness](validation.md), then add RL-specific
+assertions for the public interface and action contract.
+
+```python
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+from jax2onnx import allclose
+
+onnx_model = onnx.load(model_path)
+onnx.checker.check_model(onnx_model)
+onnx.shape_inference.infer_shapes(onnx_model)
+
+session = ort.InferenceSession(
+    str(model_path),
+    providers=["CPUExecutionProvider"],
+)
+
+assert [input_.name for input_ in session.get_inputs()] == ["obs"]
+assert [output.name for output in session.get_outputs()] == ["action"]
+
+obs = np.linspace(-2.0, 2.0, 4 * OBS_DIM, dtype=np.float32).reshape(4, OBS_DIM)
+passed, message = allclose(
+    continuous_policy,
+    str(model_path),
+    inputs=[obs],
+    rtol=1e-5,
+    atol=1e-5,
+)
+assert passed, message
+```
+
+Run at least a few concrete batch sizes through ONNX Runtime when the export
+uses a symbolic batch dimension:
+
+```python
+for batch_size in (1, 2, 7):
+    obs = np.linspace(
+        -1.5,
+        1.5,
+        batch_size * OBS_DIM,
+        dtype=np.float32,
+    ).reshape(batch_size, OBS_DIM)
+
+    action = session.run(["action"], {"obs": obs})[0]
+    assert action.shape[0] == batch_size
+```
+
+For a continuous actor with final `tanh`, also validate the action range:
+
+```python
+action = session.run(["action"], {"obs": obs})[0]
+assert np.max(action) <= 1.0 + 1e-6
+assert np.min(action) >= -1.0 - 1e-6
+```
+
+For a discrete actor, validate that action indices stay in range:
+
+```python
+action = session.run(["action"], {"obs": obs})[0]
+assert action.ndim == 1
+assert np.all(action >= 0)
+assert np.all(action < NUM_ACTIONS)
+```
+
+## Scope
+
+This pattern is policy-only. It is not intended to export:
+
+- `env.step` or simulator dynamics
+- Brax, Gymnax, MJX, or other environment loops
+- PPO/SAC `train_step` functions
+- optimizer state or replay buffers
+- stochastic sampling branches that require a runtime PRNG key
+- recurrent policy state; model that as an explicit interface such as
+  `obs, h -> action, h_next` in a separate design
+
+If a training actor needs flags such as `deterministic=True` or
+`use_running_average=True`, bind those choices before export so the ONNX model
+represents the exact inference contract.

--- a/docs/user_guide/rl_policy_deployment.md
+++ b/docs/user_guide/rl_policy_deployment.md
@@ -18,7 +18,8 @@ The reference examples are listed in [Examples](examples.md):
 - `DiscreteArgmaxPolicy`: `obs -> argmax(logits)`
 
 Both are registered as `examples.rl` exports and run through the standard
-generated example-test path.
+generated example-test path, including ONNX checker, shape inference, runtime
+parity, dynamic-batch execution, and action-contract assertions.
 
 ## Export Contract
 

--- a/docs/user_guide/validation.md
+++ b/docs/user_guide/validation.md
@@ -69,6 +69,9 @@ The zero-valued arrays keep the example minimal. For deployment decisions,
 repeat the runtime and numerical checks with representative inputs and
 tolerances appropriate for the model and dtype.
 
+For reinforcement-learning actors, also validate the policy-specific public
+interface and action contract in [RL Policy Deployment](rl_policy_deployment.md).
+
 ## Dynamic Dimensions
 
 Use symbolic dimensions such as `"B"` for export when the model should accept

--- a/jax2onnx/plugins/examples/rl/policies.py
+++ b/jax2onnx/plugins/examples/rl/policies.py
@@ -168,6 +168,79 @@ def _policy_contract(
     return _check
 
 
+def _runtime_obs_inputs(
+    obs_factory: Callable[[int], npt.NDArray[np.float32]],
+) -> list[list[npt.NDArray[np.float32]]]:
+    return [[obs_factory(batch_size)] for batch_size in (1, 2, 7)]
+
+
+def _runtime_batch_size(inputs: Sequence[Any]) -> int:
+    if len(inputs) != 1:
+        raise AssertionError(f"Expected one runtime input, got {len(inputs)}.")
+    obs = np.asarray(inputs[0])
+    if obs.ndim != 2:
+        raise AssertionError(f"Expected rank-2 obs input, got shape {obs.shape}.")
+    return int(obs.shape[0])
+
+
+def _single_runtime_output(outputs: Sequence[Any]) -> npt.NDArray[Any]:
+    if len(outputs) != 1:
+        raise AssertionError(f"Expected one runtime output, got {len(outputs)}.")
+    return np.asarray(outputs[0])
+
+
+def _continuous_runtime_contract(
+    *,
+    inputs: Sequence[Any],
+    outputs: Sequence[Any],
+    **_: Any,
+) -> bool:
+    batch_size = _runtime_batch_size(inputs)
+    action = _single_runtime_output(outputs)
+    expected_shape = (batch_size, CONTINUOUS_ACTION_DIM)
+    if action.shape != expected_shape:
+        raise AssertionError(
+            f"Continuous policy action shape mismatch: expected {expected_shape}, "
+            f"got {action.shape}."
+        )
+    if action.dtype != np.float32:
+        raise AssertionError(
+            f"Continuous policy action dtype mismatch: expected float32, "
+            f"got {action.dtype}."
+        )
+    if not np.all(np.isfinite(action)):
+        raise AssertionError("Continuous policy produced non-finite actions.")
+    if np.min(action) < -1.0 - 1e-6 or np.max(action) > 1.0 + 1e-6:
+        raise AssertionError("Continuous policy actions escaped tanh range [-1, 1].")
+    return True
+
+
+def _discrete_runtime_contract(
+    *,
+    inputs: Sequence[Any],
+    outputs: Sequence[Any],
+    **_: Any,
+) -> bool:
+    batch_size = _runtime_batch_size(inputs)
+    action = _single_runtime_output(outputs)
+    expected_shape = (batch_size,)
+    if action.shape != expected_shape:
+        raise AssertionError(
+            f"Discrete policy action shape mismatch: expected {expected_shape}, "
+            f"got {action.shape}."
+        )
+    if action.dtype != np.int32:
+        raise AssertionError(
+            f"Discrete policy action dtype mismatch: expected int32, got {action.dtype}."
+        )
+    if np.any(action < 0) or np.any(action >= DISCRETE_NUM_ACTIONS):
+        raise AssertionError(
+            "Discrete policy produced action indices outside "
+            f"[0, {DISCRETE_NUM_ACTIONS})."
+        )
+    return True
+
+
 register_example(
     component="ContinuousTanhPolicy",
     description="Deterministic continuous-control RL policy: obs -> tanh(mean_action).",
@@ -188,11 +261,14 @@ register_example(
             "run_only_dynamic": True,
             "run_only_f32_variant": True,
             "check_onnx_load": True,
+            "check_onnx_shape_inference": True,
             "post_check_onnx_graph": _policy_contract(
                 [
                     "Gemm:Bx32 -> Tanh:Bx32 -> Gemm:Bx6 -> Tanh:Bx6",
                 ],
             ),
+            "runtime_input_values": _runtime_obs_inputs(representative_continuous_obs),
+            "post_check_onnx_runtime": _continuous_runtime_contract,
         },
     ],
 )
@@ -217,11 +293,14 @@ register_example(
             "run_only_dynamic": True,
             "run_only_f32_variant": True,
             "check_onnx_load": True,
+            "check_onnx_shape_inference": True,
             "post_check_onnx_graph": _policy_contract(
                 [
                     "Gemm:Bx16 -> Tanh:Bx16 -> Gemm:Bx4 -> ArgMax:B",
                 ],
             ),
+            "runtime_input_values": _runtime_obs_inputs(representative_discrete_obs),
+            "post_check_onnx_runtime": _discrete_runtime_contract,
         },
     ],
 )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - User Guide:
       - Getting Started: user_guide/getting_started.md
       - Validation & Deployment Readiness: user_guide/validation.md
+      - RL Policy Deployment: user_guide/rl_policy_deployment.md
       - Known Limitations: user_guide/known_limitations.md
       - Browser/WASM Deployment: user_guide/browser_wasm.md
       - API Reference: user_guide/api.md

--- a/tests/t_generator.py
+++ b/tests/t_generator.py
@@ -680,6 +680,18 @@ def make_test_function(tp: dict[str, Any]):
                 testcase_name,
             )
 
+        def _runtime_input_for_current_precision(value: Any) -> np.ndarray:
+            arr = np.asarray(value)
+            dtype = arr.dtype
+            if not current_enable_double_precision:
+                if dtype == np.float64:
+                    dtype = np.float32
+                elif dtype == np.int64:
+                    dtype = np.int32
+            elif np.issubdtype(dtype, np.floating):
+                dtype = np.float64
+            return np.asarray(value, dtype=dtype)
+
         context_path = tp.get("context", "default.unknown").split(".")
         opset_version = tp.get("opset_version", 23)
         model_folder_path = os.path.join("onnx", *context_path)
@@ -797,16 +809,9 @@ def make_test_function(tp: dict[str, Any]):
 
                 xs_for_num_check = []
                 for val_from_tc in input_values_from_testcase:
-                    arr = np.asarray(val_from_tc)
-                    dt = arr.dtype
-                    if not current_enable_double_precision:
-                        if dt == np.float64:
-                            dt = np.float32
-                        elif dt == np.int64:
-                            dt = np.int32
-                    elif np.issubdtype(dt, np.floating):
-                        dt = np.float64
-                    xs_for_num_check.append(np.asarray(val_from_tc, dtype=dt))
+                    xs_for_num_check.append(
+                        _runtime_input_for_current_precision(val_from_tc)
+                    )
 
                 passed, msg = allclose(
                     callable_obj,
@@ -923,7 +928,9 @@ def make_test_function(tp: dict[str, Any]):
                 runtime_input_sets = [input_values_from_testcase]
 
             for runtime_case_index, runtime_inputs_raw in enumerate(runtime_input_sets):
-                runtime_inputs = [np.asarray(v) for v in runtime_inputs_raw]
+                runtime_inputs = [
+                    _runtime_input_for_current_precision(v) for v in runtime_inputs_raw
+                ]
                 runtime_outputs = _run_onnx_model_for_shape_check(
                     onnx_model,
                     runtime_inputs,
@@ -1114,7 +1121,8 @@ def make_test_function(tp: dict[str, Any]):
                 try:
                     # Use the same potentially float64 inputs for ONNX runtime
                     onnx_runtime_inputs = [
-                        np.asarray(v) for v in input_values_from_testcase
+                        _runtime_input_for_current_precision(v)
+                        for v in input_values_from_testcase
                     ]
                     onnx_outputs_numerical = _run_onnx_model_for_shape_check(
                         onnx_model,

--- a/tests/t_generator.py
+++ b/tests/t_generator.py
@@ -749,7 +749,7 @@ def make_test_function(tp: dict[str, Any]):
 
         logger.info(f"Model saved to: {model_path}")
 
-        # --- ONNX checker and runtime session (if requested) ---
+        # --- ONNX checker and shape inference (if requested) ---
         if tp.get("check_onnx_load", False):
             onnx_model = onnx.load_model(model_path)
             if _cast_output_types_need_fix(onnx_model):
@@ -759,6 +759,19 @@ def make_test_function(tp: dict[str, Any]):
                     "emit a stable graph."
                 )
             onnx.checker.check_model(onnx_model)
+
+        if tp.get("check_onnx_shape_inference", False):
+            try:
+                onnx_model = onnx.shape_inference.infer_shapes(onnx_model)
+            except Exception as e:
+                raise AssertionError(
+                    f"ONNX shape inference failed for '{testcase_name}': {e}"
+                ) from e
+            if _cast_output_types_need_fix(onnx_model):
+                raise AssertionError(
+                    f"Shape-inferred ONNX model for '{testcase_name}' has "
+                    "Cast/CastLike value_info dtype mismatches."
+                )
 
         # Optional per-test override: skip numeric validation entirely
         if tp.get("skip_numeric_validation", False):
@@ -892,6 +905,41 @@ def make_test_function(tp: dict[str, Any]):
         # If we reach here, it means numeric validation was skipped or not applicable.
         # We can add more conditions or logging if needed.
         # ------------------------------------------------------------------
+
+        post_check_runtime = tp.get("post_check_onnx_runtime")
+        if post_check_runtime is not None:
+            if not callable(post_check_runtime):
+                raise TypeError(
+                    f"Test '{testcase_name}': post_check_onnx_runtime must be callable."
+                )
+
+            runtime_input_sets = tp.get("runtime_input_values")
+            if runtime_input_sets is None:
+                if input_values_from_testcase is None:
+                    raise AssertionError(
+                        f"Test '{testcase_name}': post_check_onnx_runtime requires "
+                        "`runtime_input_values` or `input_values`."
+                    )
+                runtime_input_sets = [input_values_from_testcase]
+
+            for runtime_case_index, runtime_inputs_raw in enumerate(runtime_input_sets):
+                runtime_inputs = [np.asarray(v) for v in runtime_inputs_raw]
+                runtime_outputs = _run_onnx_model_for_shape_check(
+                    onnx_model,
+                    runtime_inputs,
+                    onnx_input_names_from_testcase,
+                )
+                contract_result = post_check_runtime(
+                    onnx_model=onnx_model,
+                    inputs=runtime_inputs,
+                    outputs=runtime_outputs,
+                    testcase=tp,
+                )
+                assert contract_result is not False, (
+                    f"Runtime ONNX contract check failed for '{testcase_name}' "
+                    f"(runtime_input_values[{runtime_case_index}])."
+                )
+            logger.info(f"Runtime ONNX contract checks passed for '{testcase_name}'.")
 
         # --- Function Count Check ---
         if expected_num_funcs is not None:


### PR DESCRIPTION
Summary:
- Add deterministic RL policy examples for continuous and discrete deployment contracts.
- Document the RL policy deployment pattern: stable `obs -> action`, dynamic batch, no runtime RNG/training/state inputs.
- Harden the standard generated example path with optional ONNX shape inference and runtime contract hooks.
- Use the integrated `register_example` metadata for RL runtime checks: extra batch sizes plus continuous action range and discrete action index assertions.
- Update the 0.14.2 roadmap entry so the upcoming-version notes match this PR.
- Address Copilot feedback by normalizing runtime-contract inputs to the active f32/f64 precision variant before ONNX Runtime execution.

Validation:
- `poetry run pytest -q tests/examples/test_rl.py` -> `2 passed`
- f64 generator smoke: float32 `runtime_input_values` against an f64 model -> pass
- `poetry run pytest -q tests/extra_tests/framework/test_coverage_docs.py::test_examples_doc_lists_registered_example_testcases` -> `1 passed`
- `poetry run mypy --config-file pyproject.toml jax2onnx/plugins/examples/rl/policies.py` -> pass
- `poetry run black --check tests/t_generator.py jax2onnx/plugins/examples/rl/policies.py` -> pass
- `poetry run ruff check tests/t_generator.py jax2onnx/plugins/examples/rl/policies.py` -> pass
- `poetry run mkdocs build --strict` -> pass; only dependency deprecation warnings from MkDocs/Mkdocstrings
- Commit hooks through `accf535a`: black/ruff as applicable, reflection guardrails, mypy, repository policy checks -> pass

Notes:
- Continuing on branch `codex/rl-policy-export-contract-v0`; no further direct pushes to `main`.
- Generated ONNX artifacts from local tests were removed and are not part of this PR.